### PR TITLE
Fix Windows server startup

### DIFF
--- a/scripts/copy-runtime-deps.js
+++ b/scripts/copy-runtime-deps.js
@@ -38,5 +38,31 @@ function copyRequiredFile(sourcePath, destinationName) {
   console.log(`[build] copied ${destinationName}`);
 }
 
+function copyWindowsCppRuntime() {
+  if (target !== "win64") return;
+
+  const systemRoot = process.env.SystemRoot || process.env.WINDIR;
+  if (!systemRoot) {
+    throw new Error("SystemRoot is required to bundle the Windows C++ runtime");
+  }
+
+  const systemDir = path.join(systemRoot, "System32");
+  // mediasoup-worker is built with MSVC.  These app-local redistributable
+  // DLLs prevent STATUS_DLL_NOT_FOUND (0xC0000135) on clean Windows installs.
+  const runtimeFiles = fs.readdirSync(systemDir).filter((file) =>
+    /^(?:concrt140|msvcp140(?:_[a-z0-9_]+)?|vcruntime140(?:_[a-z0-9_]+)?)\.dll$/i.test(file)
+  );
+
+  const normalizedRuntimeFiles = new Set(runtimeFiles.map((file) => file.toLowerCase()));
+  if (!normalizedRuntimeFiles.has("vcruntime140.dll") || !normalizedRuntimeFiles.has("msvcp140.dll")) {
+    throw new Error(`Microsoft Visual C++ runtime DLLs not found in ${systemDir}`);
+  }
+
+  for (const runtimeFile of runtimeFiles) {
+    copyRequiredFile(path.join(systemDir, runtimeFile), runtimeFile);
+  }
+}
+
 copyRequiredFile(sqliteSource, "better_sqlite3.node");
 copyRequiredFile(workerSource, workerName);
+copyWindowsCppRuntime();

--- a/server-app/scripts/prepare-server-sidecar.mjs
+++ b/server-app/scripts/prepare-server-sidecar.mjs
@@ -78,3 +78,19 @@ for (const runtimeFile of runtimeFiles) {
   }
   console.log(`Prepared server runtime file: ${runtimeTarget}`);
 }
+
+if (process.platform === "win32") {
+  const windowsRuntimeFiles = fs.readdirSync(sourceDir).filter((file) =>
+    /^(?:concrt140|msvcp140(?:_[a-z0-9_]+)?|vcruntime140(?:_[a-z0-9_]+)?)\.dll$/i.test(file)
+  );
+  if (windowsRuntimeFiles.length === 0) {
+    throw new Error(
+      `Windows C++ runtime DLLs are missing next to ${source}. ` +
+      "Build the server with npm run build:win64 before packaging the tray app."
+    );
+  }
+  for (const runtimeFile of windowsRuntimeFiles) {
+    fs.copyFileSync(path.join(sourceDir, runtimeFile), path.join(binariesDir, runtimeFile));
+    console.log(`Prepared Windows C++ runtime: ${runtimeFile}`);
+  }
+}

--- a/server-app/src-tauri/tauri.windows.conf.json
+++ b/server-app/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": [
+      "binaries/better_sqlite3.node",
+      "binaries/mediasoup-worker*",
+      "binaries/*.dll"
+    ]
+  }
+}

--- a/serverCore.js
+++ b/serverCore.js
@@ -4646,7 +4646,12 @@ function buildSelfSignedTlsCertificate() {
   return selfsigned.generate(
     [{ name: "commonName", value: preferredCommonName }],
     {
-      keySize: 4096,
+      // A 4096-bit key is needlessly expensive for the locally trusted,
+      // self-signed certificate.  On slower Windows machines node-forge
+      // creates it synchronously and the first launch looks like a hung app
+      // for tens of seconds.  2048-bit RSA remains broadly compatible with
+      // browsers while making first-run certificate creation near-instant.
+      keySize: 2048,
       days: 365,
       algorithm: "sha256",
       extensions: [
@@ -5437,12 +5442,26 @@ function warnIfDockerAnnouncedIpLooksInternal(announcedIp) {
 
 (async () => {
   console.log("[INIT] Starting mediasoup worker");
-  worker = await mediasoup.createWorker({
-    rtcMinPort: RTC_PORT_RANGE.start,
-    rtcMaxPort: RTC_PORT_RANGE.end,
-    logLevel: "warn",
-    logTags: ["info", "ice", "dtls", "rtp", "srtp", "rtcp"],
-  });
+  try {
+    worker = await mediasoup.createWorker({
+      rtcMinPort: RTC_PORT_RANGE.start,
+      rtcMaxPort: RTC_PORT_RANGE.end,
+      logLevel: "warn",
+      logTags: ["info", "ice", "dtls", "rtp", "srtp", "rtcp"],
+    });
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    // 0xC0000135 is Windows' STATUS_DLL_NOT_FOUND.  Keep this diagnostic
+    // close to the actual cause; the mediasoup error otherwise only exposes
+    // the opaque decimal exit code from its child process.
+    if (process.platform === "win32" && /(?:3221225781|c0000135)/i.test(message)) {
+      console.error(
+        "[INIT] mediasoup worker could not load a required Windows runtime DLL " +
+        "(0xC0000135). Reinstall Talktome; the installer must include the Microsoft Visual C++ runtime."
+      );
+    }
+    throw err;
+  }
   console.log("[INIT] Worker created with PID:", worker.pid);
   console.log(`[INIT] RTC ports: ${RTC_PORT_RANGE.start}-${RTC_PORT_RANGE.end}`);
 


### PR DESCRIPTION
## What changed
- reduce first-run self-signed certificate generation from 4096 to 2048 bits
- bundle the MSVC runtime DLLs required by mediasoup-worker on Windows
- add a clear diagnostic for Windows STATUS_DLL_NOT_FOUND (0xC0000135)

## Root cause
The initial synchronous 4096-bit certificate generation made first launch appear unresponsive, while the mediasoup worker could not start on clean Windows installations without the Visual C++ runtime.

## Validation
- `node --check` for changed JavaScript files
- `npm --prefix server-app run build:ui`
- `cargo check --manifest-path server-app/src-tauri/Cargo.toml`
- `git diff --check`