### PR TITLE
Add media dropout diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ docker run -d --restart unless-stopped --name talktome \
 ```
 
 Open `https://<HOST-IP>:8443/`. Allow the HTTPS port and the configured RTC port range in your firewall.
+The Admin `Config` page can restart the server. Docker deployments use their
+configured restart policy (as in the examples above).
 
 ### macOS Test Builds
 

--- a/bridge-client/src-tauri/src/bridge_media.rs
+++ b/bridge-client/src-tauri/src/bridge_media.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, VecDeque};
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{ToSocketAddrs, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::mpsc::{sync_channel, SyncSender};
+use std::sync::mpsc::{sync_channel, SyncSender, TrySendError};
 use std::sync::{
     atomic::{AtomicI32, AtomicU64, Ordering},
     Arc, Mutex,
@@ -36,6 +36,28 @@ fn ffmpeg_command() -> Command {
         Command::new(resolve_ffmpeg_path().unwrap_or_else(|| PathBuf::from("ffmpeg")));
     configure_ffmpeg_command(&mut command);
     command
+}
+
+fn spawn_ffmpeg_stderr_reader(
+    stream: impl Read + Send + 'static,
+    stream_id: String,
+    direction: &'static str,
+    warning_count: Arc<AtomicU64>,
+    last_warning: Arc<Mutex<Option<String>>>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        for line in BufReader::new(stream).lines().map_while(Result::ok) {
+            let message = line.trim();
+            if message.is_empty() {
+                continue;
+            }
+            warning_count.fetch_add(1, Ordering::Relaxed);
+            if let Ok(mut latest) = last_warning.lock() {
+                *latest = Some(message.to_string());
+            }
+            eprintln!("[bridge-media][{direction}][{stream_id}][ffmpeg] {message}");
+        }
+    })
 }
 
 #[cfg(windows)]
@@ -192,6 +214,10 @@ pub struct BridgeMediaInputStats {
     pub stream_id: String,
     pub rms_db: f32,
     pub captured_frames: u64,
+    pub dropped_chunks: u64,
+    pub dropped_frames: u64,
+    pub ffmpeg_warning_count: u64,
+    pub last_ffmpeg_warning: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -200,6 +226,8 @@ pub struct BridgeMediaOutputStats {
     pub stream_id: String,
     pub decoded_frames: u64,
     pub decoded_bytes: u64,
+    pub ffmpeg_warning_count: u64,
+    pub last_ffmpeg_warning: Option<String>,
 }
 
 #[derive(Default)]
@@ -244,8 +272,13 @@ struct BridgeInputRuntime {
     last_error: Arc<Mutex<Option<String>>>,
     level_milli_db: Arc<AtomicI32>,
     captured_frames: Arc<AtomicU64>,
+    dropped_chunks: Arc<AtomicU64>,
+    dropped_frames: Arc<AtomicU64>,
+    ffmpeg_warning_count: Arc<AtomicU64>,
+    last_ffmpeg_warning: Arc<Mutex<Option<String>>>,
     sender: Option<SyncSender<Vec<u8>>>,
     writer: Option<JoinHandle<()>>,
+    stderr_reader: Option<JoinHandle<()>>,
 }
 
 struct BridgeOutputRuntime {
@@ -254,7 +287,10 @@ struct BridgeOutputRuntime {
     last_error: Arc<Mutex<Option<String>>>,
     decoded_frames: Arc<AtomicU64>,
     decoded_bytes: Arc<AtomicU64>,
+    ffmpeg_warning_count: Arc<AtomicU64>,
+    last_ffmpeg_warning: Arc<Mutex<Option<String>>>,
     reader: Option<JoinHandle<()>>,
+    stderr_reader: Option<JoinHandle<()>>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -497,6 +533,10 @@ impl BridgeInputRuntime {
         let callback_level = Arc::clone(&level_milli_db);
         let captured_frames = Arc::new(AtomicU64::new(0));
         let callback_captured_frames = Arc::clone(&captured_frames);
+        let dropped_chunks = Arc::new(AtomicU64::new(0));
+        let callback_dropped_chunks = Arc::clone(&dropped_chunks);
+        let dropped_frames = Arc::new(AtomicU64::new(0));
+        let callback_dropped_frames = Arc::clone(&dropped_frames);
         let stream = device
             .build_input_stream::<f32, _, _>(
                 config,
@@ -520,7 +560,12 @@ impl BridgeInputRuntime {
                     callback_level
                         .store(rms_milli_db(sum_squares, sample_count), Ordering::Relaxed);
                     callback_captured_frames.fetch_add(frames as u64, Ordering::Relaxed);
-                    let _ = callback_sender.try_send(bytes);
+                    if let Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) =
+                        callback_sender.try_send(bytes)
+                    {
+                        callback_dropped_chunks.fetch_add(1, Ordering::Relaxed);
+                        callback_dropped_frames.fetch_add(frames as u64, Ordering::Relaxed);
+                    }
                 },
                 move |err| {
                     let message = format!("bridge input stream error: {err}");
@@ -569,7 +614,7 @@ impl BridgeInputRuntime {
             ])
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .map_err(|err| format!("failed to start ffmpeg Opus encoder: {err}"))?;
         let mut stdin = match child.stdin.take() {
@@ -580,6 +625,18 @@ impl BridgeInputRuntime {
                 return Err("ffmpeg encoder stdin is unavailable".to_string());
             }
         };
+        let stderr = child.stderr.take();
+        let ffmpeg_warning_count = Arc::new(AtomicU64::new(0));
+        let last_ffmpeg_warning = Arc::new(Mutex::new(None));
+        let stderr_reader = stderr.map(|stderr| {
+            spawn_ffmpeg_stderr_reader(
+                stderr,
+                request.stream_id.clone(),
+                "input",
+                Arc::clone(&ffmpeg_warning_count),
+                Arc::clone(&last_ffmpeg_warning),
+            )
+        });
         let child = Arc::new(Mutex::new(child));
         let writer = thread::spawn(move || {
             while let Ok(bytes) = receiver.recv() {
@@ -595,8 +652,13 @@ impl BridgeInputRuntime {
             last_error,
             level_milli_db,
             captured_frames,
+            dropped_chunks,
+            dropped_frames,
+            ffmpeg_warning_count,
+            last_ffmpeg_warning,
             sender: Some(sender),
             writer: Some(writer),
+            stderr_reader,
         })
     }
 
@@ -609,6 +671,9 @@ impl BridgeInputRuntime {
         }
         if let Some(writer) = self.writer.take() {
             let _ = writer.join();
+        }
+        if let Some(stderr_reader) = self.stderr_reader.take() {
+            let _ = stderr_reader.join();
         }
     }
 }
@@ -841,7 +906,7 @@ impl BridgeOutputRuntime {
             ])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .map_err(|err| format!("failed to start ffmpeg Opus decoder: {err}"))?;
         let mut stdin = match child.stdin.take() {
@@ -875,6 +940,18 @@ impl BridgeOutputRuntime {
                 return Err("ffmpeg decoder stdout is unavailable".to_string());
             }
         };
+        let stderr = child.stderr.take();
+        let ffmpeg_warning_count = Arc::new(AtomicU64::new(0));
+        let last_ffmpeg_warning = Arc::new(Mutex::new(None));
+        let stderr_reader = stderr.map(|stderr| {
+            spawn_ffmpeg_stderr_reader(
+                stderr,
+                request.stream_id.clone(),
+                "output",
+                Arc::clone(&ffmpeg_warning_count),
+                Arc::clone(&last_ffmpeg_warning),
+            )
+        });
         let child = Arc::new(Mutex::new(child));
         let reader_queue = Arc::clone(&queue);
         let last_error = Arc::new(Mutex::new(None));
@@ -924,7 +1001,10 @@ impl BridgeOutputRuntime {
             last_error,
             decoded_frames,
             decoded_bytes,
+            ffmpeg_warning_count,
+            last_ffmpeg_warning,
             reader: Some(reader),
+            stderr_reader,
         })
     }
 
@@ -935,6 +1015,9 @@ impl BridgeOutputRuntime {
         }
         if let Some(reader) = self.reader.take() {
             let _ = reader.join();
+        }
+        if let Some(stderr_reader) = self.stderr_reader.take() {
+            let _ = stderr_reader.join();
         }
     }
 }
@@ -1082,6 +1165,10 @@ fn status_from(state: &BridgeMediaState) -> BridgeMediaStatus {
             stream_id: stream_id.clone(),
             rms_db: runtime.level_milli_db.load(Ordering::Relaxed) as f32 / 1000.0,
             captured_frames: runtime.captured_frames.load(Ordering::Relaxed),
+            dropped_chunks: runtime.dropped_chunks.load(Ordering::Relaxed),
+            dropped_frames: runtime.dropped_frames.load(Ordering::Relaxed),
+            ffmpeg_warning_count: runtime.ffmpeg_warning_count.load(Ordering::Relaxed),
+            last_ffmpeg_warning: read_last_error(&runtime.last_ffmpeg_warning),
         })
         .collect::<Vec<_>>();
     let mut output_stream_stats = state
@@ -1091,6 +1178,8 @@ fn status_from(state: &BridgeMediaState) -> BridgeMediaStatus {
             stream_id: stream_id.clone(),
             decoded_frames: runtime.decoded_frames.load(Ordering::Relaxed),
             decoded_bytes: runtime.decoded_bytes.load(Ordering::Relaxed),
+            ffmpeg_warning_count: runtime.ffmpeg_warning_count.load(Ordering::Relaxed),
+            last_ffmpeg_warning: read_last_error(&runtime.last_ffmpeg_warning),
         })
         .collect::<Vec<_>>();
     input_stream_ids.sort();

--- a/bridge-client/src/app.js
+++ b/bridge-client/src/app.js
@@ -1778,9 +1778,31 @@ async function heartbeatManagedSessions() {
   ));
   if (!sessions.length) return;
 
+  let nativeMediaStatus = null;
+  if (invoke) {
+    nativeMediaStatus = await invoke("get_bridge_media_status").catch((error) => {
+      console.warn("failed to collect Bridge media diagnostics", error);
+      return null;
+    });
+  }
+  const inputStatsById = new Map((nativeMediaStatus?.inputStreamStats || []).map((entry) => [
+    String(entry.streamId || ""),
+    entry
+  ]));
+  const outputStatsById = new Map((nativeMediaStatus?.outputStreamStats || []).map((entry) => [
+    String(entry.streamId || ""),
+    entry
+  ]));
+
   for (const session of sessions) {
     try {
-      await bridgeApi("POST", managedSessionPath(session, "/heartbeat"), {});
+      const input = inputStatsById.get(session.inputStreamId) || null;
+      const outputs = [...session.outputs.values()]
+        .map((output) => outputStatsById.get(output.streamId))
+        .filter(Boolean);
+      await bridgeApi("POST", managedSessionPath(session, "/heartbeat"), {
+        mediaDiagnostics: input || outputs.length ? { input, outputs } : null
+      });
       if (session.error && session.statusLabel === "Server offline") {
         session.error = null;
         session.statusLabel = null;

--- a/public/admin.html
+++ b/public/admin.html
@@ -2387,6 +2387,15 @@
               </div>
             </section>
 
+            <section id="container-restart-panel" class="config-panel is-hidden" aria-labelledby="container-restart-heading">
+              <h3 id="container-restart-heading">Server restart</h3>
+              <div class="setting-meta">
+                <div>Restarts the server. Connected clients will be disconnected briefly.</div>
+                <div>Docker deployments use their configured restart policy.</div>
+              </div>
+              <button type="button" id="container-restart-btn" class="warning">Restart server</button>
+            </section>
+
             <section class="config-panel" aria-labelledby="config-backup-heading">
               <h3 id="config-backup-heading">Backup and restore</h3>
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -64,6 +64,8 @@ const configExportBtn = document.getElementById('config-export-btn');
 const configImportBtn = document.getElementById('config-import-btn');
 const configImportFile = document.getElementById('config-import-file');
 const apiKeyCopyBtn = document.getElementById('api-key-copy-btn');
+const containerRestartPanel = document.getElementById('container-restart-panel');
+const containerRestartBtn = document.getElementById('container-restart-btn');
 const mediaNetworkMeta = document.getElementById('media-network-meta');
 const mediaNetworkQrContainer = document.getElementById('media-network-qr');
 const mediaNetworkQrButton = document.getElementById('media-network-qr-button');
@@ -1152,6 +1154,8 @@ function formatStatusPacketLoss(networkStats) {
 }
 
 function renderAdminStatus(payload = {}) {
+  const canRestartContainer = Boolean(adminState.isSuperAdmin);
+  containerRestartPanel?.classList.toggle('is-hidden', !canRestartContainer);
   latestAdminStatus = payload;
   const users = Array.isArray(payload.users) ? [...payload.users] : [];
   const feeds = Array.isArray(payload.feeds) ? [...payload.feeds] : [];
@@ -3240,6 +3244,33 @@ if (apiKeyCopyBtn) {
       window.setTimeout(() => {
         apiKeyCopyBtn.disabled = false;
       }, 250);
+    }
+  });
+}
+
+if (containerRestartBtn) {
+  containerRestartBtn.addEventListener('click', async () => {
+    if (!confirm('Restart the server now? All connected clients will be disconnected briefly.')) {
+      return;
+    }
+
+    containerRestartBtn.disabled = true;
+    containerRestartBtn.textContent = 'Restarting…';
+    try {
+      const res = await authedFetch('/admin/restart', { method: 'POST' });
+      const payload = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        showMessage(payload.error || 'Failed to restart server', 'error', 'config');
+        containerRestartBtn.disabled = false;
+        containerRestartBtn.textContent = 'Restart server';
+        return;
+      }
+      showMessage('✅ Server restart requested. Reconnecting…', 'success', 'config');
+    } catch (err) {
+      console.error('Failed to restart server:', err);
+      showMessage('❌ Failed to restart server', 'error', 'config');
+      containerRestartBtn.disabled = false;
+      containerRestartBtn.textContent = 'Restart server';
     }
   });
 }

--- a/public/client.js
+++ b/public/client.js
@@ -653,7 +653,26 @@ function collectMediaNetworkStatsFromReport(report, summary) {
     const packetsReceived = Number(stats.packetsReceived);
     if (!Number.isFinite(packetsLost) || !Number.isFinite(packetsReceived)) return;
     summary.packetsLost += Math.max(0, packetsLost);
+    summary.packetsReceived += Math.max(0, packetsReceived);
     summary.packetsTotal += Math.max(0, packetsLost) + Math.max(0, packetsReceived);
+    if (stats.type === 'inbound-rtp') {
+      const jitter = Number(stats.jitter);
+      if (Number.isFinite(jitter) && jitter >= 0) summary.jitters.push(jitter * 1000);
+      summary.packetsDiscarded += Math.max(0, Number(stats.packetsDiscarded) || 0);
+      summary.concealedSamples += Math.max(0, Number(stats.concealedSamples) || 0);
+      summary.concealmentEvents += Math.max(0, Number(stats.concealmentEvents) || 0);
+      const jitterBufferDelay = Number(stats.jitterBufferDelay);
+      const jitterBufferEmittedCount = Number(stats.jitterBufferEmittedCount);
+      if (
+        Number.isFinite(jitterBufferDelay)
+        && jitterBufferDelay >= 0
+        && Number.isFinite(jitterBufferEmittedCount)
+        && jitterBufferEmittedCount > 0
+      ) {
+        summary.jitterBufferDelaySeconds += jitterBufferDelay;
+        summary.jitterBufferEmittedCount += jitterBufferEmittedCount;
+      }
+    }
   });
 }
 
@@ -668,7 +687,18 @@ async function reportMediaNetworkStats() {
   mediaNetworkStatsReportInFlight = true;
   try {
     const reports = await Promise.allSettled(transports.map((transport) => transport.getStats()));
-    const summary = { roundTripTimes: [], packetsLost: 0, packetsTotal: 0 };
+    const summary = {
+      roundTripTimes: [],
+      jitters: [],
+      packetsLost: 0,
+      packetsReceived: 0,
+      packetsTotal: 0,
+      packetsDiscarded: 0,
+      concealedSamples: 0,
+      concealmentEvents: 0,
+      jitterBufferDelaySeconds: 0,
+      jitterBufferEmittedCount: 0,
+    };
     reports.forEach((result) => {
       if (result.status === 'fulfilled') {
         collectMediaNetworkStatsFromReport(result.value, summary);
@@ -681,12 +711,25 @@ async function reportMediaNetworkStats() {
     const packetLossPercent = summary.packetsTotal > 0
       ? (summary.packetsLost / summary.packetsTotal) * 100
       : null;
+    const averageJitterMs = summary.jitters.length
+      ? summary.jitters.reduce((total, value) => total + value, 0) / summary.jitters.length
+      : null;
+    const averageJitterBufferMs = summary.jitterBufferEmittedCount > 0
+      ? (summary.jitterBufferDelaySeconds / summary.jitterBufferEmittedCount) * 1000
+      : null;
 
     socket.emit('media-network-stats', {
       roundTripMs: Number.isFinite(averageRoundTripMs) ? Math.round(averageRoundTripMs) : null,
       packetLossPercent: Number.isFinite(packetLossPercent)
         ? Math.round(packetLossPercent * 10) / 10
         : null,
+      jitterMs: Number.isFinite(averageJitterMs) ? Math.round(averageJitterMs) : null,
+      jitterBufferMs: Number.isFinite(averageJitterBufferMs) ? Math.round(averageJitterBufferMs) : null,
+      packetsLost: summary.packetsLost,
+      packetsReceived: summary.packetsReceived,
+      packetsDiscarded: summary.packetsDiscarded,
+      concealedSamples: summary.concealedSamples,
+      concealmentEvents: summary.concealmentEvents,
     });
   } catch (error) {
     console.debug('Unable to collect WebRTC network stats:', error);
@@ -3252,6 +3295,17 @@ document.addEventListener("DOMContentLoaded", () => {
     renderMediaConnectionStatus();
   }
 
+  function reportMediaTransportEvent(direction, event, state, detail = null) {
+    if (!socket.connected) return;
+    socket.emit('media-transport-event', {
+      direction,
+      event,
+      state: state || 'unknown',
+      detail: detail ? String(detail).slice(0, 500) : null,
+      clientTime: new Date().toISOString(),
+    });
+  }
+
   function bindMediaTransportStatus(transport, direction) {
     if (!transport || !['send', 'receive'].includes(direction)) return;
     mediaConnectionState[direction] = transport.connectionState || 'new';
@@ -3264,6 +3318,7 @@ document.addEventListener("DOMContentLoaded", () => {
       mediaConnectionState[direction] = state || transport.connectionState || 'unknown';
       if (state === 'connected') mediaConnectionState.iceError = null;
       renderMediaConnectionStatus();
+      reportMediaTransportEvent(direction, 'connection-state', mediaConnectionState[direction]);
     });
 
     transport.on('icegatheringstatechange', (state) => {
@@ -3271,6 +3326,7 @@ document.addEventListener("DOMContentLoaded", () => {
       if (direction === 'receive' && transport !== recvTransport) return;
       mediaConnectionState[`${direction}Ice`] = state || transport.iceGatheringState || 'unknown';
       renderMediaConnectionStatus();
+      reportMediaTransportEvent(direction, 'ice-gathering-state', mediaConnectionState[`${direction}Ice`]);
     });
 
     transport.on('icecandidateerror', (event) => {
@@ -3278,6 +3334,7 @@ document.addEventListener("DOMContentLoaded", () => {
       if (direction === 'receive' && transport !== recvTransport) return;
       mediaConnectionState.iceError = describeIceCandidateError(event);
       renderMediaConnectionStatus();
+      reportMediaTransportEvent(direction, 'ice-candidate-error', 'warning', mediaConnectionState.iceError);
     });
   }
 

--- a/serverCore.js
+++ b/serverCore.js
@@ -639,6 +639,7 @@ const adminStatusStreams = new Set();
 let adminStatusBroadcastTimer = null;
 let pendingAdminStatusReason = "status-changed";
 let pendingAdminStatusRefresh = { users: false, conferences: false, feeds: false };
+let containerRestartScheduled = false;
 
 function parseCookieHeader(header) {
   const cookies = {};
@@ -694,6 +695,43 @@ function requireSuperAdmin(req, res, next) {
     return res.status(403).json({ error: "Superadmin required" });
   }
   next();
+}
+
+function quoteWindowsCommandArgument(value) {
+  return `"${String(value).replace(/(["\\])/g, "\\$1")}"`;
+}
+
+function restartServerProcess() {
+  if (containerRestartScheduled) return;
+  containerRestartScheduled = true;
+
+  // Give the response a moment to reach the browser before ending the current
+  // process. Containers are restarted by their runtime; every other install
+  // starts an identical replacement process after this one has released its ports.
+  setTimeout(() => {
+    console.log("[ADMIN] Server restart requested.");
+    if (!isRunningInContainer()) {
+      const restartArgs = process.argv.slice(1);
+      const launcher = process.platform === "win32"
+        ? childProcess.spawn("cmd.exe", [
+          "/d", "/s", "/c",
+          `timeout /t 2 /nobreak >NUL & start \"\" /b ${[
+            process.execPath,
+            ...restartArgs,
+          ].map(quoteWindowsCommandArgument).join(" ")}`,
+        ], { detached: true, stdio: "ignore", windowsHide: true })
+        : childProcess.spawn("sh", [
+          "-c",
+          'sleep 2; exec "$@"',
+          "talktome-restart",
+          process.execPath,
+          ...restartArgs,
+        ], { detached: true, stdio: "ignore" });
+      launcher.unref();
+    }
+    server.close(() => process.exit(0));
+    setTimeout(() => process.exit(0), 1_000).unref();
+  }, 150).unref();
 }
 
 function writeAdminStatusEvent(stream, event, payload) {
@@ -2742,8 +2780,50 @@ function normalizeBrowserMediaStats(payload = {}) {
   if (Number.isFinite(packetLossPercent) && packetLossPercent >= 0 && packetLossPercent <= 100) {
     normalized.packetLossPercent = Math.round(packetLossPercent * 10) / 10;
   }
+  for (const key of [
+    "jitterMs",
+    "jitterBufferMs",
+    "packetsLost",
+    "packetsReceived",
+    "packetsDiscarded",
+    "concealedSamples",
+    "concealmentEvents",
+  ]) {
+    const value = Number(payload?.[key]);
+    if (Number.isFinite(value) && value >= 0 && value <= Number.MAX_SAFE_INTEGER) {
+      normalized[key] = Math.round(value);
+    }
+  }
 
   return Object.keys(normalized).length ? normalized : null;
+}
+
+function logBrowserMediaStats(peer, socketId, stats) {
+  const now = Date.now();
+  const previous = peer.browserMediaStats || null;
+  const delta = (key) => previous ? Math.max(0, Number(stats[key] || 0) - Number(previous[key] || 0)) : 0;
+  const lostDelta = delta("packetsLost");
+  const discardedDelta = delta("packetsDiscarded");
+  const concealedSamplesDelta = delta("concealedSamples");
+  const concealmentEventsDelta = delta("concealmentEvents");
+  const hasNewProblem = lostDelta > 0 || discardedDelta > 0 || concealmentEventsDelta > 0;
+  const periodicLogDue = !peer.lastMediaDiagnosticsLogAt || now - peer.lastMediaDiagnosticsLogAt >= 30_000;
+  if (!hasNewProblem && !periodicLogDue) return;
+
+  const timestamp = new Date(now).toISOString();
+  const label = `${peer.kind || "client"}:${peer.userId ?? peer.feedId ?? peer.name ?? socketId}`;
+  const prefix = hasNewProblem ? "[MEDIA][WEBRTC][LOSS]" : "[MEDIA][WEBRTC][STATS]";
+  const method = hasNewProblem ? console.warn : console.log;
+  method(
+    `${prefix} ${timestamp} ${label} socket=${socketId} `
+    + `rttMs=${stats.roundTripMs ?? "unknown"} jitterMs=${stats.jitterMs ?? "unknown"} `
+    + `jitterBufferMs=${stats.jitterBufferMs ?? "unknown"} lossPct=${stats.packetLossPercent ?? "unknown"} `
+    + `packets=recv:${stats.packetsReceived ?? 0},lost:${stats.packetsLost ?? 0}(+${lostDelta}),`
+    + `discarded:${stats.packetsDiscarded ?? 0}(+${discardedDelta}) `
+    + `concealment=events:${stats.concealmentEvents ?? 0}(+${concealmentEventsDelta}),`
+    + `samples:${stats.concealedSamples ?? 0}(+${concealedSamplesDelta},~${Math.round(concealedSamplesDelta / 48)}ms)`
+  );
+  peer.lastMediaDiagnosticsLogAt = now;
 }
 
 function getFreshBrowserMediaStats(peer, now = Date.now()) {
@@ -2870,6 +2950,7 @@ function buildAdminStatusSnapshot() {
     appVersion: SERVER_APP_VERSION,
     generatedAt: new Date(now).toISOString(),
     serverStartedAt: statusIsoTimestamp(SERVER_STARTED_AT),
+    runningInContainer: isRunningInContainer(),
     users,
     feeds,
     bridges,
@@ -2889,6 +2970,15 @@ function buildAdminStatusSnapshot() {
 
 app.get("/admin/status", requireAdmin, (req, res) => {
   res.json(buildAdminStatusSnapshot());
+});
+
+app.post("/admin/restart", requireAdmin, requireSuperAdmin, (req, res) => {
+  if (containerRestartScheduled) {
+    return res.status(409).json({ error: "A server restart is already in progress" });
+  }
+
+  res.status(202).json({ restarting: true });
+  restartServerProcess();
 });
 
 app.get("/admin/status/events", requireAdmin, (req, res) => {
@@ -3813,6 +3903,7 @@ app.post(
   requireBridgeApiAuth,
   requireBridgeControlSession,
   (req, res) => {
+    logBridgeMediaDiagnostics(req.bridgeSession, req.body?.mediaDiagnostics);
     res.json({ ok: true });
   }
 );
@@ -3977,6 +4068,10 @@ app.post(
         }),
         appData: producerAppData,
       });
+      attachProducerMediaDiagnostics(
+        producer,
+        `bridge:${req.bridgeSession.bridgeId}/${req.bridgeSession.kind}:${req.bridgeSession.userId ?? req.bridgeSession.feedId}`
+      );
       producer.__startedAt = Date.now();
       peer.producers.set(producer.id, producer);
       producer.__recipientDeliveries = new Map();
@@ -5242,6 +5337,45 @@ function buildGatewayAudioRtpParameters({
   };
 }
 
+function attachProducerMediaDiagnostics(producer, label) {
+  if (!producer?.on) return;
+  let previousScore = null;
+  producer.on("score", (scores = []) => {
+    const compact = (Array.isArray(scores) ? scores : []).map((entry) => ({
+      ssrc: entry?.ssrc ?? null,
+      score: entry?.score ?? null,
+    }));
+    const serialized = JSON.stringify(compact);
+    if (serialized === previousScore) return;
+    previousScore = serialized;
+    const degraded = compact.some((entry) => Number(entry.score) < 10);
+    const method = degraded ? console.warn : console.log;
+    method(
+      `[MEDIA][RTP][PRODUCER-SCORE] ${new Date().toISOString()} ${label} `
+      + `producer=${producer.id} scores=${serialized}`
+    );
+  });
+}
+
+function attachWebRtcTransportDiagnostics(socketId, direction, transport) {
+  if (!transport?.on) return;
+  const log = (event, state, extra = "") => {
+    console.log(
+      `[MEDIA][WEBRTC][SERVER-TRANSPORT] ${new Date().toISOString()} socket=${socketId} `
+      + `direction=${direction} transport=${transport.id} event=${event} state=${state || "unknown"}`
+      + (extra ? ` ${extra}` : "")
+    );
+  };
+  transport.on("icestatechange", (state) => log("ice-state", state));
+  transport.on("iceselectedtuplechange", (tuple) => log(
+    "ice-selected-tuple",
+    transport.iceState,
+    `tuple=${tuple?.protocol || "unknown"}:${tuple?.remoteIp || "unknown"}:${tuple?.remotePort || "unknown"}`
+  ));
+  transport.on("dtlsstatechange", (state) => log("dtls-state", state));
+  transport.observer?.on?.("close", () => log("close", "closed"));
+}
+
 function queueBridgeControlEvent(session, event, payload = {}) {
   if (!session || session.closed) return;
   const relevantEvents = new Set([
@@ -5484,6 +5618,87 @@ function requireBridgeControlSession(req, res, next) {
     return res.status(410).json({ error: "Bridge peer is no longer available" });
   }
   next();
+}
+
+function finiteDiagnosticCounter(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? Math.floor(number) : 0;
+}
+
+function logBridgeMediaDiagnostics(session, payload) {
+  const input = payload?.input && typeof payload.input === "object" ? payload.input : null;
+  const now = Date.now();
+  const timestamp = new Date(now).toISOString();
+  const label = `${session.bridgeId}/${session.kind}:${session.userId ?? session.feedId}`;
+  const previousOutputs = session.mediaOutputDiagnostics || {};
+  const nextOutputs = Object.create(null);
+  for (const output of Array.isArray(payload?.outputs) ? payload.outputs : []) {
+    const streamId = String(output?.streamId || "unknown").slice(0, 160);
+    const warningCount = finiteDiagnosticCounter(output?.ffmpegWarningCount);
+    const previousWarningCount = finiteDiagnosticCounter(previousOutputs[streamId]?.ffmpegWarningCount);
+    const warningDelta = Math.max(0, warningCount - previousWarningCount);
+    const lastWarning = typeof output?.lastFfmpegWarning === "string"
+      ? output.lastFfmpegWarning.trim().slice(0, 500)
+      : "";
+    if (warningDelta > 0) {
+      console.warn(
+        `[MEDIA][BRIDGE][FFMPEG] ${timestamp} ${label} output=${streamId} `
+        + `warnings=+${warningDelta}/${warningCount}`
+        + (lastWarning ? ` last=${JSON.stringify(lastWarning)}` : "")
+      );
+    }
+    nextOutputs[streamId] = {
+      ffmpegWarningCount: warningCount,
+      decodedFrames: finiteDiagnosticCounter(output?.decodedFrames),
+    };
+  }
+  session.mediaOutputDiagnostics = nextOutputs;
+  if (!input) return;
+
+  const current = {
+    capturedFrames: finiteDiagnosticCounter(input.capturedFrames),
+    droppedChunks: finiteDiagnosticCounter(input.droppedChunks),
+    droppedFrames: finiteDiagnosticCounter(input.droppedFrames),
+    ffmpegWarningCount: finiteDiagnosticCounter(input.ffmpegWarningCount),
+    rmsDb: Number.isFinite(Number(input.rmsDb)) ? Number(input.rmsDb) : null,
+    lastFfmpegWarning: typeof input.lastFfmpegWarning === "string"
+      ? input.lastFfmpegWarning.trim().slice(0, 500)
+      : "",
+    reportedAt: now,
+  };
+  const previous = session.mediaDiagnostics || null;
+
+  if (previous) {
+    const droppedChunksDelta = Math.max(0, current.droppedChunks - previous.droppedChunks);
+    const droppedFramesDelta = Math.max(0, current.droppedFrames - previous.droppedFrames);
+    const warningDelta = Math.max(0, current.ffmpegWarningCount - previous.ffmpegWarningCount);
+    if (droppedChunksDelta > 0 || droppedFramesDelta > 0) {
+      console.warn(
+        `[MEDIA][BRIDGE][DROP] ${timestamp} ${label} `
+        + `chunks=+${droppedChunksDelta}/${current.droppedChunks} `
+        + `frames=+${droppedFramesDelta}/${current.droppedFrames}`
+      );
+    }
+    if (warningDelta > 0) {
+      console.warn(
+        `[MEDIA][BRIDGE][FFMPEG] ${timestamp} ${label} warnings=+${warningDelta}/${current.ffmpegWarningCount}`
+        + (current.lastFfmpegWarning ? ` last=${JSON.stringify(current.lastFfmpegWarning)}` : "")
+      );
+    }
+    if (current.capturedFrames === previous.capturedFrames && now - previous.reportedAt >= 5_000) {
+      console.warn(`[MEDIA][BRIDGE][STALL] ${timestamp} ${label} capturedFrames=${current.capturedFrames}`);
+    }
+  }
+
+  if (!session.lastMediaHealthLogAt || now - session.lastMediaHealthLogAt >= 60_000) {
+    console.log(
+      `[MEDIA][BRIDGE][HEALTH] ${timestamp} ${label} capturedFrames=${current.capturedFrames} `
+      + `droppedChunks=${current.droppedChunks} droppedFrames=${current.droppedFrames} `
+      + `ffmpegWarnings=${current.ffmpegWarningCount} rmsDb=${current.rmsDb ?? "unknown"}`
+    );
+    session.lastMediaHealthLogAt = now;
+  }
+  session.mediaDiagnostics = current;
 }
 
 function resolveBridgeRequestIp(req) {
@@ -5923,11 +6138,26 @@ io.on("connection", (socket) => {
 
     const stats = normalizeBrowserMediaStats(payload);
     if (!stats) return;
+    logBrowserMediaStats(peer, socket.id, stats);
     peer.browserMediaStats = {
       ...stats,
       reportedAt: Date.now(),
     };
     scheduleAdminStatusBroadcast("browser-media-stats-updated");
+  });
+
+  socket.on("media-transport-event", (payload = {}) => {
+    const peer = peers.get(socket.id);
+    const direction = ["send", "receive"].includes(payload?.direction) ? payload.direction : "unknown";
+    const event = String(payload?.event || "unknown").slice(0, 80);
+    const state = String(payload?.state || "unknown").slice(0, 80);
+    const detail = typeof payload?.detail === "string" ? payload.detail.trim().slice(0, 500) : "";
+    const label = `${peer?.kind || "client"}:${peer?.userId ?? peer?.feedId ?? peer?.name ?? socket.id}`;
+    console.log(
+      `[MEDIA][WEBRTC][TRANSPORT] ${new Date().toISOString()} ${label} socket=${socket.id} `
+      + `direction=${direction} event=${event} state=${state}`
+      + (detail ? ` detail=${JSON.stringify(detail)}` : "")
+    );
   });
 
   socket.on("register-user", ({ id, name, kind = "user", force = false, guestProfileUserId = null } = {}, callback) => {
@@ -6529,6 +6759,7 @@ io.on("connection", (socket) => {
       });
 
       peers.get(socket.id).sendTransport = transport;
+      attachWebRtcTransportDiagnostics(socket.id, "send", transport);
       console.log(`[TRANSPORT] Send transport created: ${transport.id}`);
       console.log(`[TRANSPORT] ICE Candidates:`, transport.iceCandidates);
 
@@ -6573,6 +6804,7 @@ io.on("connection", (socket) => {
       });
 
       peers.get(socket.id).recvTransport = transport;
+      attachWebRtcTransportDiagnostics(socket.id, "receive", transport);
       console.log(`[TRANSPORT] Recv transport created: ${transport.id}`);
       console.log(`[TRANSPORT] ICE Candidates:`, transport.iceCandidates);
 
@@ -6716,6 +6948,7 @@ io.on("connection", (socket) => {
         rtpParameters: rtpParameters || buildGatewayAudioRtpParameters(),
         appData,
       });
+      attachProducerMediaDiagnostics(producer, `plain:${peer.kind}:${peer.userId ?? peer.feedId ?? socket.id}`);
 
       producer.__startedAt = Date.now();
       peer.producers.set(producer.id, producer);
@@ -6917,6 +7150,7 @@ io.on("connection", (socket) => {
             rtpParameters,
             appData,
           });
+          attachProducerMediaDiagnostics(producer, `webrtc:${peer.kind}:${peer.userId ?? peer.feedId ?? socket.id}`);
 
           producer.__startedAt = Date.now();
           peer.producers.set(producer.id, producer);


### PR DESCRIPTION
## Summary

Adds server, bridge and browser diagnostics for investigating long-running audio dropouts.

- logs Bridge buffer drops, stalls and FFmpeg warnings
- records RTP producer quality plus WebRTC loss, jitter and transport events
- adds the Admin restart control across deployment modes

## Why

Long-running feed recordings showed periodic and intermittent gaps. The new telemetry makes the next soak test attributable to capture, RTP, WebRTC or client transport.

## Validation

- `cargo test`
- `cargo fmt --check --manifest-path bridge-client/src-tauri/Cargo.toml`
- `node --check` for changed JavaScript
- `npm test`
- `git diff --check`