### PR TITLE
Keep bridge sessions alive via SSE

### DIFF
--- a/serverCore.js
+++ b/serverCore.js
@@ -3967,6 +3967,10 @@ app.get(
       }
       try {
         res.write(": heartbeat\n\n");
+        // The Bridge keeps this SSE stream in its native process. Its webview
+        // heartbeat may be throttled while the app is hidden, but a writable
+        // native stream still proves that this control session is alive.
+        session.lastSeenAt = Date.now();
       } catch {
         session.eventStreams.delete(stream);
         clearInterval(stream.heartbeat);


### PR DESCRIPTION
## What changed
- refresh Bridge session liveness after each successfully written native SSE heartbeat

## Why
The Bridge audio capture and native event stream can remain alive while the hidden webview delays its JavaScript heartbeat. The server previously expired that live session after 30 seconds and restarted the feed.

## Validation
- node --check serverCore.js
- npm test
- git diff --check