### PR TITLE
Retain paused talk consumers safely

### DIFF
--- a/bridge-client/src/app.js
+++ b/bridge-client/src/app.js
@@ -2052,6 +2052,7 @@ async function startManagedSession(port, { reuse = false, silentRetry = false, r
     if (bridgePortHasOutput(port)) {
       const active = await bridgeApi("GET", managedSessionPath(session, "/active-producers"));
       for (const producerPayload of active.producers || []) {
+        if (producerPayload?.retainOnly) continue;
         await startManagedConsumer(session, producerPayload);
       }
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.0",
   "main": "server.js",
   "scripts": {
-    "test": "node --test webrtcConfig.test.js",
+    "test": "node --test *.test.js",
     "start": "node server.js",
     "radio:ptt": "node gateway/radioGateway.js ptt",
     "radio:play": "node gateway/radioGateway.js play",

--- a/producerReconciliation.js
+++ b/producerReconciliation.js
@@ -1,0 +1,86 @@
+"use strict";
+
+function normalizeProducerType(producer) {
+  return String(producer?.appData?.type || "").trim().toLowerCase();
+}
+
+function buildProducerDeliverySignature(appData = {}) {
+  return [
+    appData?.type || "",
+    appData?.id ?? "",
+    appData?.targetPeer || "",
+  ].join(":");
+}
+
+function producerDeliveryChanged(previousAppData, nextAppData) {
+  return (
+    !previousAppData
+    || !nextAppData
+    || buildProducerDeliverySignature(previousAppData) !== buildProducerDeliverySignature(nextAppData)
+  );
+}
+
+function shouldAnnounceProducerDelivery({
+  previousAppData,
+  nextAppData,
+  forceAnnounce = false,
+} = {}) {
+  return Boolean(
+    nextAppData
+    && (forceAnnounce || producerDeliveryChanged(previousAppData, nextAppData))
+  );
+}
+
+function getRetainedTalkDelivery(producer, recipientSocketId) {
+  if (
+    !producer
+    || producer.closed
+    || normalizeProducerType(producer) !== "talk"
+    || !(producer.__recipientDeliveries instanceof Map)
+  ) {
+    return null;
+  }
+
+  const appData = producer.__recipientDeliveries.get(recipientSocketId);
+  if (!appData || typeof appData !== "object") return null;
+  return { recipientSocketId, appData };
+}
+
+function resolveProducerReconciliationDelivery({
+  producer,
+  recipientSocketId,
+  activeDelivery = null,
+} = {}) {
+  if (!producer || producer.closed || !recipientSocketId) return null;
+
+  // Paused producers are not active. Only a previously delivered dynamic talk
+  // producer may be retained so an existing consumer survives the PTT pause.
+  if (producer.paused) {
+    const retainedDelivery = getRetainedTalkDelivery(producer, recipientSocketId);
+    return retainedDelivery
+      ? { ...retainedDelivery, retainOnly: true }
+      : null;
+  }
+
+  if (activeDelivery?.appData) {
+    return {
+      recipientSocketId,
+      appData: activeDelivery.appData,
+      retainOnly: false,
+    };
+  }
+
+  // The client clears talk targets immediately before the pause reaches the
+  // server. Retain the prior delivery during that short signaling transition.
+  const retainedDelivery = getRetainedTalkDelivery(producer, recipientSocketId);
+  return retainedDelivery
+    ? { ...retainedDelivery, retainOnly: true }
+    : null;
+}
+
+module.exports = {
+  getRetainedTalkDelivery,
+  producerDeliveryChanged,
+  resolveProducerReconciliationDelivery,
+  shouldAnnounceProducerDelivery,
+};

--- a/producerReconciliation.test.js
+++ b/producerReconciliation.test.js
@@ -1,0 +1,149 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  getRetainedTalkDelivery,
+  producerDeliveryChanged,
+  resolveProducerReconciliationDelivery,
+  shouldAnnounceProducerDelivery,
+} = require("./producerReconciliation");
+
+const recipientSocketId = "recipient-1";
+const deliveryAppData = { type: "user", id: 6, targetPeer: recipientSocketId };
+
+function createProducer(overrides = {}) {
+  return {
+    id: "producer-1",
+    closed: false,
+    paused: false,
+    appData: { type: "talk" },
+    __recipientDeliveries: new Map([[recipientSocketId, deliveryAppData]]),
+    ...overrides,
+  };
+}
+
+test("keeps an existing dynamic talk delivery while its producer is paused", () => {
+  const producer = createProducer({ paused: true });
+
+  assert.deepEqual(
+    resolveProducerReconciliationDelivery({ producer, recipientSocketId }),
+    {
+      recipientSocketId,
+      appData: deliveryAppData,
+      retainOnly: true,
+    }
+  );
+});
+
+test("does not expose paused static producers as active or retained", () => {
+  for (const type of ["user", "conference", "guest", "feed"]) {
+    const producer = createProducer({
+      paused: true,
+      appData: { type, id: 1 },
+    });
+
+    assert.equal(
+      resolveProducerReconciliationDelivery({
+        producer,
+        recipientSocketId,
+        activeDelivery: { recipientSocketId, appData: producer.appData },
+      }),
+      null
+    );
+  }
+});
+
+test("does not turn a never-delivered paused talk producer into an active delivery", () => {
+  const producer = createProducer({
+    paused: true,
+    __recipientDeliveries: new Map(),
+  });
+
+  assert.equal(
+    resolveProducerReconciliationDelivery({
+      producer,
+      recipientSocketId,
+      activeDelivery: { recipientSocketId, appData: deliveryAppData },
+    }),
+    null
+  );
+});
+
+test("returns an unpaused current delivery as active", () => {
+  const producer = createProducer();
+  const activeDelivery = {
+    recipientSocketId,
+    appData: { type: "conference", id: 3 },
+  };
+
+  assert.deepEqual(
+    resolveProducerReconciliationDelivery({
+      producer,
+      recipientSocketId,
+      activeDelivery,
+    }),
+    {
+      recipientSocketId,
+      appData: activeDelivery.appData,
+      retainOnly: false,
+    }
+  );
+});
+
+test("retains a talk delivery during the target-clear to pause transition", () => {
+  const producer = createProducer({ paused: false });
+
+  assert.deepEqual(
+    resolveProducerReconciliationDelivery({ producer, recipientSocketId }),
+    {
+      recipientSocketId,
+      appData: deliveryAppData,
+      retainOnly: true,
+    }
+  );
+});
+
+test("does not retain closed, unrelated, or never-delivered talk producers", () => {
+  assert.equal(
+    getRetainedTalkDelivery(createProducer({ closed: true }), recipientSocketId),
+    null
+  );
+  assert.equal(
+    getRetainedTalkDelivery(createProducer(), "recipient-2"),
+    null
+  );
+  assert.equal(
+    getRetainedTalkDelivery(
+      createProducer({ __recipientDeliveries: new Map() }),
+      recipientSocketId
+    ),
+    null
+  );
+});
+
+test("detects changed routing metadata and forces a resume announcement", () => {
+  assert.equal(
+    producerDeliveryChanged(deliveryAppData, { ...deliveryAppData }),
+    false
+  );
+  assert.equal(
+    producerDeliveryChanged(deliveryAppData, { ...deliveryAppData, id: 7 }),
+    true
+  );
+  assert.equal(
+    shouldAnnounceProducerDelivery({
+      previousAppData: deliveryAppData,
+      nextAppData: { ...deliveryAppData },
+      forceAnnounce: false,
+    }),
+    false
+  );
+  assert.equal(
+    shouldAnnounceProducerDelivery({
+      previousAppData: deliveryAppData,
+      nextAppData: { ...deliveryAppData },
+      forceAnnounce: true,
+    }),
+    true
+  );
+});

--- a/public/client.js
+++ b/public/client.js
@@ -8957,6 +8957,18 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
           || peerConsumers.has(streamKey)
           || (targetStreamMap.get(targetKey)?.has(streamKey) ?? false);
 
+        if (payload?.retainOnly) {
+          logReceiveDiagnostic(
+            alreadyHave ? 'consumer-retained-paused-producer' : 'retain-only-producer-skipped',
+            {
+              producerId: payload.producerId || null,
+              streamKey,
+              targetKey,
+            }
+          );
+          continue;
+        }
+
         if (alreadyHave) continue;
         await handleIncomingProducer(payload);
       }

--- a/serverCore.js
+++ b/serverCore.js
@@ -13,6 +13,11 @@ const QRCode = require("qrcode");
 const { getDataDir } = require("./dataPaths");
 const { ApplePttPushService } = require("./applePttPushService");
 const { buildWebRtcListenInfos, resolveClientIceConfig } = require("./webrtcConfig");
+const {
+  producerDeliveryChanged,
+  resolveProducerReconciliationDelivery,
+  shouldAnnounceProducerDelivery,
+} = require("./producerReconciliation");
 
 function resolveServerAppVersion() {
   let version = process.env.TALKTOME_VERSION || process.env.npm_package_version || "";
@@ -4176,6 +4181,7 @@ app.post(
           producerId: producer.id,
           appData: producer.appData,
           speakerSocketId: req.bridgeSession.id,
+          forceAnnounce: true,
         });
         syncPeerCompanionState(peer, { reason: "bridge-producer-resumed" });
         broadcastRuntimeUserStates("bridge-producer-resumed");
@@ -5854,12 +5860,13 @@ function waitForBridgeRtpHandshake(transport) {
   });
 }
 
-function buildBridgeProducerPayload(peerId, producerId, appData) {
+function buildBridgeProducerPayload(peerId, producerId, appData, { retainOnly = false } = {}) {
   const speakerPeer = peers.get(peerId);
   return {
     peerId,
     producerId,
     appData,
+    retainOnly: Boolean(retainOnly),
     speakerUserId: speakerPeer?.userId ?? speakerPeer?.guestProfileUserId ?? null,
     speakerName: speakerPeer?.name || null,
     speakerKind: speakerPeer?.kind || null,
@@ -5887,25 +5894,36 @@ function listActiveProducersForPeer(peer, peerId) {
   for (const [otherPeerId, otherPeer] of peers) {
     if (otherPeerId === peerId) continue;
     for (const [producerId, producer] of otherPeer.producers) {
-      // A paused producer still exists and its consumer must stay attached.
-      // Excluding it makes periodic reconciliation recreate a consumer on
-      // every talk/pause cycle.
       if (!producer || producer.closed) continue;
       const appData = producer.appData;
       const type = String(appData?.type || "").trim().toLowerCase();
-      if (type === "feed" && loadFeedIds().has(String(appData.id))) {
-        response.push(buildBridgeProducerPayload(otherPeerId, producerId, appData));
-      } else if (type === "conference" && loadConferenceIds().has(String(appData.id))) {
-        response.push(buildBridgeProducerPayload(otherPeerId, producerId, appData));
-      } else if (["user", "talk", "guest"].includes(type)) {
-        const delivery = resolveProducerRecipientDeliveries({
-          appData,
-          speakerSocketId: otherPeerId,
-        }).find((candidate) => candidate.recipientSocketId === peerId);
-        if (delivery?.appData) {
-          response.push(buildBridgeProducerPayload(otherPeerId, producerId, delivery.appData));
+      let activeDelivery = null;
+
+      if (!producer.paused) {
+        if (type === "feed" && loadFeedIds().has(String(appData.id))) {
+          activeDelivery = { recipientSocketId: peerId, appData };
+        } else if (type === "conference" && loadConferenceIds().has(String(appData.id))) {
+          activeDelivery = { recipientSocketId: peerId, appData };
+        } else if (["user", "talk", "guest"].includes(type)) {
+          activeDelivery = resolveProducerRecipientDeliveries({
+            appData,
+            speakerSocketId: otherPeerId,
+          }).find((candidate) => candidate.recipientSocketId === peerId) || null;
         }
       }
+
+      const reconciliationDelivery = resolveProducerReconciliationDelivery({
+        producer,
+        recipientSocketId: peerId,
+        activeDelivery,
+      });
+      if (!reconciliationDelivery?.appData) continue;
+      response.push(buildBridgeProducerPayload(
+        otherPeerId,
+        producerId,
+        reconciliationDelivery.appData,
+        { retainOnly: reconciliationDelivery.retainOnly }
+      ));
     }
   }
   return response;
@@ -6031,14 +6049,6 @@ function resolveApplePttSpeakerName(socketId) {
   return trimmed || "Talktome";
 }
 
-function buildProducerDeliverySignature(appData = {}) {
-  return [
-    appData?.type || "",
-    appData?.id ?? "",
-    appData?.targetPeer || "",
-  ].join(":");
-}
-
 function resolveProducerRecipientDeliveriesForTargets({ targets, speakerSocketId }) {
   const deliveries = [];
   const seenRecipients = new Set();
@@ -6119,7 +6129,7 @@ function closeProducerConsumersForRecipient({ producerId, recipientSocketId }) {
   }
 }
 
-function syncProducerRecipients({ producer, speakerSocketId }) {
+function syncProducerRecipients({ producer, speakerSocketId, forceAnnounce = false }) {
   if (!producer) return [];
 
   const deliveries = resolveProducerRecipientDeliveries({
@@ -6135,17 +6145,18 @@ function syncProducerRecipients({ producer, speakerSocketId }) {
 
   for (const [recipientSocketId, previousAppData] of previousDeliveries.entries()) {
     const nextAppData = nextDeliveries.get(recipientSocketId);
-    const deliveryChanged = !nextAppData
-      || buildProducerDeliverySignature(previousAppData) !== buildProducerDeliverySignature(nextAppData);
+    const deliveryChanged = producerDeliveryChanged(previousAppData, nextAppData);
     if (!deliveryChanged) continue;
     closeProducerConsumersForRecipient({ producerId: producer.id, recipientSocketId });
   }
 
   for (const [recipientSocketId, nextAppData] of nextDeliveries.entries()) {
     const previousAppData = previousDeliveries.get(recipientSocketId);
-    const deliveryChanged = !previousAppData
-      || buildProducerDeliverySignature(previousAppData) !== buildProducerDeliverySignature(nextAppData);
-    if (!deliveryChanged) continue;
+    if (!shouldAnnounceProducerDelivery({
+      previousAppData,
+      nextAppData,
+      forceAnnounce,
+    })) continue;
     const recipientPeer = peers.get(recipientSocketId);
     if (!recipientPeer?.socket) continue;
     recipientPeer.socket.emit("new-producer", {
@@ -6159,11 +6170,20 @@ function syncProducerRecipients({ producer, speakerSocketId }) {
   return deliveries;
 }
 
-function announceProducerToRecipients({ producerId, appData, speakerSocketId }) {
+function announceProducerToRecipients({
+  producerId,
+  appData,
+  speakerSocketId,
+  forceAnnounce = false,
+}) {
   const speakerPeer = peers.get(speakerSocketId);
   const producer = speakerPeer?.producers?.get(producerId) || null;
   if (!producer) return [];
-  return syncProducerRecipients({ producer, speakerSocketId }).map((delivery) => delivery.recipientSocketId);
+  return syncProducerRecipients({
+    producer,
+    speakerSocketId,
+    forceAnnounce,
+  }).map((delivery) => delivery.recipientSocketId);
 }
 
 async function sendApplePttSpeakerStarted({ type, targetId, targets = null, speakerSocketId, reason }) {
@@ -6678,49 +6698,46 @@ io.on("connection", (socket) => {
       if (otherSocketId === socket.id) continue;
 
       for (const [producerId, producer] of otherPeer.producers) {
-        // Paused talk producers remain valid. Keep them in reconciliation so
-        // clients do not tear down and recreate their consumers while idle.
         if (!producer || producer.closed) continue;
         const appData = producer?.appData;
         if (!appData || typeof appData !== "object") continue;
         const type = String(appData.type || "").trim().toLowerCase();
+        let activeDelivery = null;
 
-        if (type === "feed") {
+        if (!producer.paused && type === "feed") {
           const feedId = appData.id;
           if (feedId == null) continue;
           const membership = loadFeedIds();
           if (membership.has(String(feedId))) {
-            response.push({ peerId: otherSocketId, producerId, appData });
+            activeDelivery = { recipientSocketId: socket.id, appData };
           }
-          continue;
-        }
-
-        if (type === "conference") {
+        } else if (!producer.paused && type === "conference") {
           const confId = appData.id;
           if (confId == null) continue;
           const membership = loadConferenceIds();
           if (membership.has(String(confId))) {
-            response.push({ peerId: otherSocketId, producerId, appData });
+            activeDelivery = { recipientSocketId: socket.id, appData };
           }
-          continue;
+        } else if (!producer.paused && (type === "user" || type === "talk")) {
+          const deliveries = resolveProducerRecipientDeliveries({ appData, speakerSocketId: otherSocketId });
+          activeDelivery = deliveries.find((candidate) => candidate.recipientSocketId === socket.id) || null;
+        } else if (!producer.paused && type === "guest") {
+          const deliveries = resolveProducerRecipientDeliveries({ appData, speakerSocketId: otherSocketId });
+          activeDelivery = deliveries.find((candidate) => candidate.recipientSocketId === socket.id) || null;
         }
 
-        if (type === "user" || type === "talk") {
-          const deliveries = resolveProducerRecipientDeliveries({ appData, speakerSocketId: otherSocketId });
-          const delivery = deliveries.find((candidate) => candidate.recipientSocketId === socket.id);
-          if (delivery?.appData) {
-            response.push({ peerId: otherSocketId, producerId, appData: delivery.appData });
-          }
-          continue;
-        }
-
-        if (type === "guest") {
-          const deliveries = resolveProducerRecipientDeliveries({ appData, speakerSocketId: otherSocketId });
-          const delivery = deliveries.find((candidate) => candidate.recipientSocketId === socket.id);
-          if (delivery?.appData) {
-            response.push({ peerId: otherSocketId, producerId, appData: delivery.appData });
-          }
-        }
+        const reconciliationDelivery = resolveProducerReconciliationDelivery({
+          producer,
+          recipientSocketId: socket.id,
+          activeDelivery,
+        });
+        if (!reconciliationDelivery?.appData) continue;
+        response.push({
+          peerId: otherSocketId,
+          producerId,
+          appData: reconciliationDelivery.appData,
+          retainOnly: Boolean(reconciliationDelivery.retainOnly),
+        });
       }
     }
 
@@ -7082,6 +7099,7 @@ io.on("connection", (socket) => {
           producerId: producer.id,
           appData,
           speakerSocketId: socket.id,
+          forceAnnounce: true,
         });
       });
 
@@ -7305,6 +7323,7 @@ io.on("connection", (socket) => {
               producerId: producer.id,
               appData,
               speakerSocketId: socket.id,
+              forceAnnounce: true,
             });
             void sendApplePttSpeakerStarted({
               type,


### PR DESCRIPTION
## Was geändert wurde

- Die ursprüngliche Bedeutung von `request-active-producers` bleibt erhalten: pausierte statische User-, Conference-, Guest- und Feed-Producer gelten weiterhin nicht als aktiv.
- Bereits ausgelieferte dynamische Talk-Producer werden während einer PTT-Pause als `retainOnly` gemeldet.
- Browser und native Bridge behalten bei `retainOnly` einen vorhandenen Consumer, erzeugen daraus aber niemals einen neuen stillen Consumer.
- Beim Resume wird der Producer erneut angekündigt; vorhandene Consumer deduplizieren das Ereignis, verlorene Consumer können sofort wiederhergestellt werden.
- Die Consumer-Cleanup-, Deduplizierungs- und Mediendiagnostik aus PR #22 bleiben erhalten.

## Ursache

Der Pausenfilter war eine beabsichtigte Active/Inactive-Abgrenzung. Der später eingeführte Warm-Talk-Producer bleibt jedoch zwischen PTT-Vorgängen pausiert bestehen. Die periodische Synchronisierung konnte deshalb nicht zwischen „pausiert, Consumer behalten“ und „Producer beendet, Consumer entfernen“ unterscheiden.

## Auswirkung

Keine stillen Consumer für pausierte statische Producer, keine Consumer-Neuanlage in jedem 10-Sekunden-Abgleich und kein Warten auf den nächsten Abgleich, wenn ein Consumer beim Resume wirklich fehlt.

## Validierung

- `node --check` für Server, Browser-Client, Bridge-Client und neue Reconciliation-Module
- `npm test` (13/13 bestanden, davon 7 neue Reconciliation-Regressionstests)
- `npm pack --dry-run` bestätigt die Paketaufnahme des neuen Laufzeitmoduls
- `git diff --check`