### PR TITLE
Skip unresponsive audio drivers

### DIFF
--- a/bridge-client/src-tauri/src/audio.rs
+++ b/bridge-client/src-tauri/src/audio.rs
@@ -1,7 +1,10 @@
 use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::{Device, SampleRate, SupportedBufferSize, SupportedStreamConfigRange};
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
+use std::collections::HashSet;
+use std::sync::{mpsc, Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::network_audio;
 
@@ -9,6 +12,8 @@ use crate::network_audio;
 pub struct AudioInventory {
     pub host: String,
     pub devices: Vec<AudioDeviceInfo>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -54,52 +59,213 @@ pub struct AudioDeviceSnapshotEntry {
     pub is_default: bool,
 }
 
+const DEVICE_DETAILS_TIMEOUT: Duration = Duration::from_secs(2);
+const SYSTEM_DIRECTION_TIMEOUT: Duration = Duration::from_secs(4);
+
+// Native driver calls cannot be cancelled safely. A timed-out worker is left
+// detached, and these sets prevent another worker from entering the same bad
+// driver path during the current process lifetime.
+static TIMED_OUT_DEVICE_PROBES: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+static TIMED_OUT_DIRECTIONS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
 pub fn list_audio_devices() -> Result<AudioInventory, String> {
     let host = cpal::default_host();
     let host_name = format!("{:?}", host.id());
-    let default_input_name = host.default_input_device().map(|device| device.to_string());
-    let default_output_name = host
-        .default_output_device()
-        .map(|device| device.to_string());
-
+    let input_probe = spawn_system_direction_probe(host_name.clone(), "input");
+    let output_probe = spawn_system_direction_probe(host_name.clone(), "output");
+    let network_scan = network_audio::audio_devices(Duration::from_millis(250));
     let mut devices = Vec::new();
+    let mut warnings = Vec::new();
 
-    match host.input_devices() {
-        Ok(input_devices) => {
-            for (index, device) in input_devices.enumerate() {
-                devices.push(describe_device(
-                    &host_name,
-                    "input",
-                    index,
-                    device,
-                    default_input_name.as_deref(),
-                )?);
-            }
-        }
-        Err(err) => eprintln!("failed to enumerate input devices: {err}"),
-    }
-
-    match host.output_devices() {
-        Ok(output_devices) => {
-            for (index, device) in output_devices.enumerate() {
-                devices.push(describe_device(
-                    &host_name,
-                    "output",
-                    index,
-                    device,
-                    default_output_name.as_deref(),
-                )?);
-            }
-        }
-        Err(err) => eprintln!("failed to enumerate output devices: {err}"),
-    }
-
-    devices.extend(network_audio::audio_devices(Duration::from_millis(250)));
+    collect_system_direction_probe(input_probe, &mut devices, &mut warnings);
+    collect_system_direction_probe(output_probe, &mut devices, &mut warnings);
+    devices.extend(network_scan.devices);
+    warnings.extend(network_scan.warnings);
 
     Ok(AudioInventory {
         host: host_name,
         devices,
+        warnings,
     })
+}
+
+struct SystemDirectionProbe {
+    direction: &'static str,
+    probe_key: String,
+    started_at: Instant,
+    receiver: Option<mpsc::Receiver<(Vec<AudioDeviceInfo>, Vec<String>)>>,
+}
+
+fn spawn_system_direction_probe(host_name: String, direction: &'static str) -> SystemDirectionProbe {
+    let probe_key = format!("{host_name}:{direction}");
+    let timed_out = TIMED_OUT_DIRECTIONS.get_or_init(|| Mutex::new(HashSet::new()));
+    if timed_out
+        .lock()
+        .is_ok_and(|directions| directions.contains(&probe_key))
+    {
+        return SystemDirectionProbe {
+            direction,
+            probe_key,
+            started_at: Instant::now(),
+            receiver: None,
+        };
+    }
+
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let started_at = Instant::now();
+    thread::spawn(move || {
+        let host = cpal::default_host();
+        let default_name = match direction {
+            "input" => host.default_input_device(),
+            "output" => host.default_output_device(),
+            _ => None,
+        }
+        .map(|device| device.to_string());
+        let result = match direction {
+            "input" => match host.input_devices() {
+                Ok(devices) => describe_devices_with_timeout(
+                    &host_name,
+                    direction,
+                    devices.enumerate(),
+                    default_name.as_deref(),
+                ),
+                Err(error) => (Vec::new(), vec![format!(
+                    "Failed to enumerate input devices: {error}"
+                )]),
+            },
+            "output" => match host.output_devices() {
+                Ok(devices) => describe_devices_with_timeout(
+                    &host_name,
+                    direction,
+                    devices.enumerate(),
+                    default_name.as_deref(),
+                ),
+                Err(error) => (Vec::new(), vec![format!(
+                    "Failed to enumerate output devices: {error}"
+                )]),
+            },
+            _ => (Vec::new(), vec![format!("Unknown audio direction: {direction}")]),
+        };
+        let _ = sender.send(result);
+    });
+
+    SystemDirectionProbe {
+        direction,
+        probe_key,
+        started_at,
+        receiver: Some(receiver),
+    }
+}
+
+fn collect_system_direction_probe(
+    probe: SystemDirectionProbe,
+    devices: &mut Vec<AudioDeviceInfo>,
+    warnings: &mut Vec<String>,
+) {
+    let timed_out = TIMED_OUT_DIRECTIONS.get_or_init(|| Mutex::new(HashSet::new()));
+    let Some(receiver) = probe.receiver else {
+        warnings.push(format!(
+            "Skipped all system audio {}s: device enumeration stopped responding earlier.",
+            probe.direction
+        ));
+        return;
+    };
+    let remaining = SYSTEM_DIRECTION_TIMEOUT.saturating_sub(probe.started_at.elapsed());
+    match receiver.recv_timeout(remaining) {
+        Ok((mut found, mut skipped)) => {
+            devices.append(&mut found);
+            warnings.append(&mut skipped);
+        }
+        Err(error) => {
+            if let Ok(mut directions) = timed_out.lock() {
+                directions.insert(probe.probe_key);
+            }
+            let reason = match error {
+                mpsc::RecvTimeoutError::Timeout => format!(
+                    "device enumeration did not respond within {} seconds",
+                    SYSTEM_DIRECTION_TIMEOUT.as_secs()
+                ),
+                mpsc::RecvTimeoutError::Disconnected => {
+                    "device enumeration stopped unexpectedly".to_string()
+                }
+            };
+            warnings.push(format!(
+                "Skipped all system audio {}s: {reason}.",
+                probe.direction
+            ));
+        }
+    }
+}
+
+fn describe_devices_with_timeout(
+    host_name: &str,
+    direction: &str,
+    devices: impl Iterator<Item = (usize, Device)>,
+    default_name: Option<&str>,
+) -> (Vec<AudioDeviceInfo>, Vec<String>) {
+    let timed_out = TIMED_OUT_DEVICE_PROBES.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut pending = Vec::new();
+    let mut warnings = Vec::new();
+
+    for (index, device) in devices {
+        let probe_key = format!("{host_name}:{direction}:{index}");
+        if timed_out
+            .lock()
+            .is_ok_and(|probes| probes.contains(&probe_key))
+        {
+            warnings.push(format!(
+                "Skipped {direction} audio device #{index}: its driver stopped responding earlier."
+            ));
+            continue;
+        }
+
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let host_name = host_name.to_string();
+        let direction = direction.to_string();
+        let default_name = default_name.map(str::to_string);
+        let started_at = Instant::now();
+        thread::spawn(move || {
+            let result = describe_device(
+                &host_name,
+                &direction,
+                index,
+                device,
+                default_name.as_deref(),
+            );
+            let _ = sender.send(result);
+        });
+        pending.push((index, probe_key, started_at, receiver));
+    }
+
+    let mut found = Vec::new();
+    for (index, probe_key, started_at, receiver) in pending {
+        let remaining = DEVICE_DETAILS_TIMEOUT.saturating_sub(started_at.elapsed());
+        match receiver.recv_timeout(remaining) {
+            Ok(Ok(device)) => found.push(device),
+            Ok(Err(error)) => warnings.push(format!(
+                "Skipped {direction} audio device #{index}: {error}"
+            )),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if let Ok(mut probes) = timed_out.lock() {
+                    probes.insert(probe_key);
+                }
+                warnings.push(format!(
+                    "Skipped {direction} audio device #{index}: its driver did not respond within {} seconds.",
+                    DEVICE_DETAILS_TIMEOUT.as_secs()
+                ));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                if let Ok(mut probes) = timed_out.lock() {
+                    probes.insert(probe_key);
+                }
+                warnings.push(format!(
+                    "Skipped {direction} audio device #{index}: its driver probe stopped unexpectedly."
+                ));
+            }
+        }
+    }
+
+    (found, warnings)
 }
 
 /// Lists endpoint identity only. In particular, this avoids supported-config

--- a/bridge-client/src-tauri/src/lib.rs
+++ b/bridge-client/src-tauri/src/lib.rs
@@ -357,12 +357,12 @@ fn get_audio_device_snapshot() -> Result<AudioDeviceSnapshot, String> {
 
 #[tauri::command]
 fn get_ndi_status() -> ndi::NdiStatus {
-    ndi::status(Duration::from_millis(250))
+    network_audio::ndi_status(Duration::from_millis(250))
 }
 
 #[tauri::command]
 fn get_omt_status() -> omt::OmtStatus {
-    omt::status(Duration::from_millis(250))
+    network_audio::omt_status(Duration::from_millis(250))
 }
 
 #[tauri::command]

--- a/bridge-client/src-tauri/src/network_audio.rs
+++ b/bridge-client/src-tauri/src/network_audio.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::sync::{
-    atomic::{AtomicI32, AtomicU64},
-    mpsc::SyncSender,
+    atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering},
+    mpsc::{self, SyncSender},
     Arc, Mutex,
 };
-use std::time::Duration;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::audio::{AudioDeviceInfo, AudioDeviceSnapshotEntry};
 use crate::bridge_media::BridgeOutputMixerSource;
@@ -34,18 +35,33 @@ pub struct InputStartRequest {
     pub dropped_frames: Arc<AtomicU64>,
 }
 
-pub fn audio_devices(wait: Duration) -> Vec<AudioDeviceInfo> {
-    std::thread::scope(|scope| {
-        let ndi_devices = scope.spawn(|| ndi::audio_devices(wait));
-        let omt_devices = scope.spawn(|| omt::audio_devices(wait));
-        let mut devices = ndi_devices.join().unwrap_or_default();
-        devices.extend(omt_devices.join().unwrap_or_default());
-        devices
-    })
+pub struct NetworkAudioScan {
+    pub devices: Vec<AudioDeviceInfo>,
+    pub warnings: Vec<String>,
+}
+
+const BACKEND_PROBE_TIMEOUT: Duration = Duration::from_secs(4);
+
+// See audio.rs: timed-out native calls stay detached, so never start another
+// probe against that backend until the Bridge process is restarted.
+static NDI_TIMED_OUT: AtomicBool = AtomicBool::new(false);
+static OMT_TIMED_OUT: AtomicBool = AtomicBool::new(false);
+
+pub fn audio_devices(wait: Duration) -> NetworkAudioScan {
+    let ndi = spawn_backend_probe("NDI", &NDI_TIMED_OUT, move || ndi::audio_devices(wait));
+    let omt = spawn_backend_probe("OMT", &OMT_TIMED_OUT, move || omt::audio_devices(wait));
+    let mut devices = Vec::new();
+    let mut warnings = Vec::new();
+
+    collect_backend_probe(ndi, BACKEND_PROBE_TIMEOUT, &mut devices, &mut warnings);
+    collect_backend_probe(omt, BACKEND_PROBE_TIMEOUT, &mut devices, &mut warnings);
+
+    NetworkAudioScan { devices, warnings }
 }
 
 pub fn audio_device_snapshot(wait: Duration) -> Vec<AudioDeviceSnapshotEntry> {
     audio_devices(wait)
+        .devices
         .into_iter()
         .map(|device| AudioDeviceSnapshotEntry {
             id: device.id,
@@ -54,6 +70,171 @@ pub fn audio_device_snapshot(wait: Duration) -> Vec<AudioDeviceSnapshotEntry> {
             is_default: false,
         })
         .collect()
+}
+
+struct BackendProbe {
+    name: &'static str,
+    timed_out: &'static AtomicBool,
+    started_at: Instant,
+    receiver: Option<mpsc::Receiver<Vec<AudioDeviceInfo>>>,
+}
+
+fn spawn_backend_probe(
+    name: &'static str,
+    timed_out: &'static AtomicBool,
+    probe: impl FnOnce() -> Vec<AudioDeviceInfo> + Send + 'static,
+) -> BackendProbe {
+    if timed_out.load(Ordering::Relaxed) {
+        return BackendProbe {
+            name,
+            timed_out,
+            started_at: Instant::now(),
+            receiver: None,
+        };
+    }
+
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let started_at = Instant::now();
+    thread::spawn(move || {
+        let _ = sender.send(probe());
+    });
+    BackendProbe {
+        name,
+        timed_out,
+        started_at,
+        receiver: Some(receiver),
+    }
+}
+
+fn collect_backend_probe(
+    probe: BackendProbe,
+    timeout: Duration,
+    devices: &mut Vec<AudioDeviceInfo>,
+    warnings: &mut Vec<String>,
+) {
+    let Some(receiver) = probe.receiver else {
+        warnings.push(format!(
+            "Skipped {} audio: its backend stopped responding earlier.",
+            probe.name
+        ));
+        return;
+    };
+    let remaining = timeout.saturating_sub(probe.started_at.elapsed());
+    match receiver.recv_timeout(remaining) {
+        Ok(mut found) => devices.append(&mut found),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            probe.timed_out.store(true, Ordering::Relaxed);
+            warnings.push(format!(
+                "Skipped {} audio: its backend did not respond within {} seconds.",
+                probe.name,
+                timeout.as_secs()
+            ));
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            probe.timed_out.store(true, Ordering::Relaxed);
+            warnings.push(format!(
+                "Skipped {} audio: its backend probe stopped unexpectedly.",
+                probe.name
+            ));
+        }
+    }
+}
+
+pub fn ndi_status(wait: Duration) -> ndi::NdiStatus {
+    if NDI_TIMED_OUT.load(Ordering::Relaxed) {
+        return ndi::NdiStatus {
+            available: false,
+            version: None,
+            runtime_path: None,
+            source_count: 0,
+            source_names: Vec::new(),
+            error: Some("NDI backend timed out and was disabled for this Bridge session".to_string()),
+        };
+    }
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let _ = sender.send(ndi::status(wait));
+    });
+    match receiver.recv_timeout(BACKEND_PROBE_TIMEOUT) {
+        Ok(status) => status,
+        Err(_) => {
+            NDI_TIMED_OUT.store(true, Ordering::Relaxed);
+            ndi::NdiStatus {
+                available: false,
+                version: None,
+                runtime_path: None,
+                source_count: 0,
+                source_names: Vec::new(),
+                error: Some(
+                    "NDI backend timed out and was disabled for this Bridge session".to_string(),
+                ),
+            }
+        }
+    }
+}
+
+pub fn omt_status(wait: Duration) -> omt::OmtStatus {
+    if OMT_TIMED_OUT.load(Ordering::Relaxed) {
+        return omt::OmtStatus {
+            available: false,
+            version: None,
+            runtime_path: None,
+            source_count: 0,
+            source_names: Vec::new(),
+            error: Some("OMT backend timed out and was disabled for this Bridge session".to_string()),
+        };
+    }
+    let (sender, receiver) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let _ = sender.send(omt::status(wait));
+    });
+    match receiver.recv_timeout(BACKEND_PROBE_TIMEOUT) {
+        Ok(status) => status,
+        Err(_) => {
+            OMT_TIMED_OUT.store(true, Ordering::Relaxed);
+            omt::OmtStatus {
+                available: false,
+                version: None,
+                runtime_path: None,
+                source_count: 0,
+                source_names: Vec::new(),
+                error: Some(
+                    "OMT backend timed out and was disabled for this Bridge session".to_string(),
+                ),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_backend_probe, spawn_backend_probe};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    static TEST_TIMED_OUT: AtomicBool = AtomicBool::new(false);
+
+    #[test]
+    fn quarantines_a_backend_that_does_not_answer_in_time() {
+        TEST_TIMED_OUT.store(false, Ordering::Relaxed);
+        let probe = spawn_backend_probe("test", &TEST_TIMED_OUT, || {
+            std::thread::sleep(Duration::from_millis(100));
+            Vec::new()
+        });
+        let mut devices = Vec::new();
+        let mut warnings = Vec::new();
+
+        collect_backend_probe(
+            probe,
+            Duration::from_millis(5),
+            &mut devices,
+            &mut warnings,
+        );
+
+        assert!(devices.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert!(TEST_TIMED_OUT.load(Ordering::Relaxed));
+    }
 }
 
 pub fn is_input_device(device_id: &str) -> bool {

--- a/bridge-client/src/app.js
+++ b/bridge-client/src/app.js
@@ -23,6 +23,7 @@ const omtRuntime = document.getElementById("omt-runtime");
 const omtRuntimeDetail = document.getElementById("omt-runtime-detail");
 const refreshOmtButton = document.getElementById("refresh-omt");
 const omtRuntimeLink = document.getElementById("omt-runtime-link");
+const audioScanStatus = document.getElementById("audio-scan-status");
 
 const invoke = window.__TAURI__?.core?.invoke;
 const listen = window.__TAURI__?.event?.listen;
@@ -47,6 +48,8 @@ const MANAGED_LEVEL_TRIGGER_DEFAULT_THRESHOLD_DB = -45;
 const MANAGED_LEVEL_TRIGGER_MIN_THRESHOLD_DB = -120;
 const MANAGED_LEVEL_TRIGGER_MAX_THRESHOLD_DB = -10;
 const MANAGED_DEFAULT_TARGET_VOLUME = 0.9;
+const AUDIO_INVENTORY_TIMEOUT_MS = 10_000;
+const AUDIO_STATUS_TIMEOUT_MS = 5_000;
 const MIN_WINDOW_HEIGHT = 260;
 const MAX_WINDOW_HEIGHT = 820;
 const ALLOWED_NDI_INFORMATION_URLS = new Set([
@@ -72,6 +75,7 @@ let managedLevelTriggerTimer = null;
 let managedRetryRunning = false;
 let managedLevelTriggerRunning = false;
 let managedInventoryWatchRunning = false;
+let managedInventoryWatchDisabled = false;
 let managedRangeInteractionActive = false;
 let lastAnnouncedInventorySignature = "";
 let lastAudioDeviceSnapshotSignature = "";
@@ -90,6 +94,24 @@ const managedPortDraftRevisions = new Map();
 const managedPortAutoSaveTimers = new Map();
 const managedPortSaveInFlight = new Set();
 const managedPortSaveQueued = new Set();
+
+function withTimeout(promise, milliseconds, label) {
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(() => {
+      reject(new Error(`${label} did not respond within ${Math.ceil(milliseconds / 1000)} seconds`));
+    }, milliseconds);
+    Promise.resolve(promise).then(
+      (value) => {
+        window.clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        window.clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
 
 function measureBridgeWindowContentHeight() {
   const shell = document.querySelector(".shell");
@@ -221,11 +243,15 @@ function renderNdiStatus(status) {
   const available = Boolean(status?.available);
   ndiRuntime.dataset.state = available ? "available" : "unavailable";
   if (!available) {
-    ndiRuntimeDetail.textContent = "Runtime not installed. NDI devices are hidden until the current NDI Runtime is installed.";
-    ndiRuntimeDetail.title = String(status?.error || "NDI Runtime not found");
+    const error = String(status?.error || "NDI Runtime not found");
+    const timedOut = /timed out|did not respond/i.test(error);
+    ndiRuntimeDetail.textContent = timedOut
+      ? "Backend did not respond. NDI devices were skipped for this session."
+      : "Runtime not installed. NDI devices are hidden until the current NDI Runtime is installed.";
+    ndiRuntimeDetail.title = error;
     if (ndiRuntimeLink) {
-      ndiRuntimeLink.href = "https://ndi.video/tools/";
-      ndiRuntimeLink.textContent = "Download NDI\nRuntime";
+      ndiRuntimeLink.href = timedOut ? "https://ndi.video/" : "https://ndi.video/tools/";
+      ndiRuntimeLink.textContent = timedOut ? "NDI® information" : "Download NDI\nRuntime";
     }
     return;
   }
@@ -245,8 +271,12 @@ function renderOmtStatus(status) {
   omtRuntime.dataset.state = available ? "available" : "unavailable";
   const version = String(status?.version || "OMT");
   if (!available) {
-    omtRuntimeDetail.textContent = "Bundled backend unavailable. Reinstall the Bridge to restore OMT devices.";
-    omtRuntimeDetail.title = String(status?.error || "Bundled OMT backend not found");
+    const error = String(status?.error || "Bundled OMT backend not found");
+    const timedOut = /timed out|did not respond/i.test(error);
+    omtRuntimeDetail.textContent = timedOut
+      ? "Backend did not respond. OMT devices were skipped for this session."
+      : "Bundled backend unavailable. Reinstall the Bridge to restore OMT devices.";
+    omtRuntimeDetail.title = error;
     return;
   }
   const sourceCount = Number(status?.sourceCount || 0);
@@ -2494,14 +2524,27 @@ async function reconcileManagedBridgeConfig(config) {
 async function refreshManagedInventoryOnly() {
   if (!invoke) return;
   await suppressWindowFocusHide(250);
-  const [inventory, ndiStatus, omtStatus] = await Promise.all([
+  const inventory = await withTimeout(
     invoke("list_audio_devices"),
-    invoke("get_ndi_status"),
-    invoke("get_omt_status")
-  ]);
+    AUDIO_INVENTORY_TIMEOUT_MS,
+    "Audio device scan"
+  );
+  managedInventoryWatchDisabled = false;
   renderInventory(inventory);
-  renderNdiStatus(ndiStatus);
-  renderOmtStatus(omtStatus);
+  const [ndiResult, omtResult] = await Promise.allSettled([
+    withTimeout(invoke("get_ndi_status"), AUDIO_STATUS_TIMEOUT_MS, "NDI status check"),
+    withTimeout(invoke("get_omt_status"), AUDIO_STATUS_TIMEOUT_MS, "OMT status check")
+  ]);
+  if (ndiResult.status === "fulfilled") {
+    renderNdiStatus(ndiResult.value);
+  } else {
+    renderNdiStatus({ available: false, error: String(ndiResult.reason) });
+  }
+  if (omtResult.status === "fulfilled") {
+    renderOmtStatus(omtResult.value);
+  } else {
+    renderOmtStatus({ available: false, error: String(omtResult.reason) });
+  }
   return inventory;
 }
 
@@ -2579,13 +2622,17 @@ async function syncManagedBridge() {
 }
 
 async function watchManagedInventory() {
-  if (managedInventoryWatchRunning || managedSyncRunning || !invoke) return;
+  if (managedInventoryWatchRunning || managedInventoryWatchDisabled || managedSyncRunning || !invoke) return;
   if (isBridgeSettingsControlFocused()) return;
   if (!serverUrlInput.value.trim() || !getBridgeCredential()) return;
 
   managedInventoryWatchRunning = true;
   try {
-    const snapshot = await invoke("get_audio_device_snapshot");
+    const snapshot = await withTimeout(
+      invoke("get_audio_device_snapshot"),
+      AUDIO_INVENTORY_TIMEOUT_MS,
+      "Audio device snapshot"
+    );
     const nextSnapshotSignature = audioDeviceSnapshotSignature(snapshot);
     if (!lastAudioDeviceSnapshotSignature) {
       lastAudioDeviceSnapshotSignature = nextSnapshotSignature;
@@ -2602,6 +2649,9 @@ async function watchManagedInventory() {
     renderManagedBridgePorts();
   } catch (error) {
     console.warn("managed inventory watch failed", error);
+    if (/audio device snapshot did not respond/i.test(String(error?.message || error))) {
+      managedInventoryWatchDisabled = true;
+    }
   } finally {
     managedInventoryWatchRunning = false;
   }
@@ -2767,6 +2817,14 @@ function renderInventory(inventory) {
   currentInventory = inventory;
   lastAudioDeviceSnapshotSignature = audioDeviceSnapshotSignature(inventory);
   renderSummary(inventory);
+  if (audioScanStatus) {
+    const warnings = Array.isArray(inventory?.warnings) ? inventory.warnings : [];
+    audioScanStatus.textContent = warnings.length
+      ? `${warnings.length} audio component${warnings.length === 1 ? " was" : "s were"} skipped because ${warnings.length === 1 ? "it" : "they"} could not be queried safely.`
+      : "";
+    audioScanStatus.title = warnings.join("\n");
+    requestBridgeWindowResize();
+  }
   if (!deviceList) {
     renderAllPortControls();
     return;
@@ -3352,29 +3410,67 @@ async function refreshDevices() {
   }
   try {
     await suppressWindowFocusHide(250);
-    const [inventory, bridgeStatus, portStatuses, ndiStatus, omtStatus] = await Promise.all([
-      invoke("list_audio_devices"),
-      invoke("get_bridge_status"),
-      localPortList ? invoke("get_audio_probe_ports_status") : Promise.resolve([]),
-      invoke("get_ndi_status"),
-      invoke("get_omt_status")
+    // Inventory probes each backend with a native timeout first. Status checks
+    // run afterwards so a quarantined backend cannot block the other results.
+    const inventoryResult = await Promise.allSettled([
+      withTimeout(invoke("list_audio_devices"), AUDIO_INVENTORY_TIMEOUT_MS, "Audio device scan")
     ]);
-    renderBridgeStatus(bridgeStatus);
-    renderInventory(inventory);
-    renderPortStatuses(portStatuses);
-    renderNdiStatus(ndiStatus);
-    renderOmtStatus(omtStatus);
-    if (serverUrlInput.value.trim() && getBridgeCredential()) {
-      try {
-        await announceBridge({ quiet: true });
-      } catch (announceError) {
-        console.warn("auto announce failed", announceError);
-        if (isServerOfflineError(announceError)) {
-          setServerConnectionState("disconnected");
-        }
-        setBridgeConnectionError(announceError);
-      }
+    const inventory = inventoryResult[0].status === "fulfilled"
+      ? inventoryResult[0].value
+      : { host: "Unavailable", devices: [], warnings: [String(inventoryResult[0].reason)] };
+    if (inventoryResult[0].status === "fulfilled") {
+      managedInventoryWatchDisabled = false;
     }
+    renderInventory(inventory);
+
+    const bridgeStatusPromise = invoke("get_bridge_status").then((status) => {
+      renderBridgeStatus(status);
+      return status;
+    });
+    const portStatusesPromise = (localPortList
+      ? invoke("get_audio_probe_ports_status")
+      : Promise.resolve([])).then((statuses) => {
+        renderPortStatuses(statuses);
+        return statuses;
+      });
+    const ndiStatusPromise = withTimeout(
+      invoke("get_ndi_status"),
+      AUDIO_STATUS_TIMEOUT_MS,
+      "NDI status check"
+    ).then((status) => {
+      renderNdiStatus(status);
+      return status;
+    });
+    const omtStatusPromise = withTimeout(
+      invoke("get_omt_status"),
+      AUDIO_STATUS_TIMEOUT_MS,
+      "OMT status check"
+    ).then((status) => {
+      renderOmtStatus(status);
+      return status;
+    });
+    const announcePromise = serverUrlInput.value.trim() && getBridgeCredential()
+      ? announceBridge({ quiet: true }).catch((announceError) => {
+          console.warn("auto announce failed", announceError);
+          if (isServerOfflineError(announceError)) {
+            setServerConnectionState("disconnected");
+          }
+          setBridgeConnectionError(announceError);
+        })
+      : Promise.resolve();
+    const statusResults = await Promise.allSettled([
+      bridgeStatusPromise,
+      portStatusesPromise,
+      ndiStatusPromise,
+      omtStatusPromise
+    ]);
+    if (statusResults[2].status === "rejected") {
+      renderNdiStatus({ available: false, error: String(statusResults[2].reason) });
+    }
+    if (statusResults[3].status === "rejected") {
+      renderOmtStatus({ available: false, error: String(statusResults[3].reason) });
+    }
+    await announcePromise;
   } catch (error) {
     console.error(error);
     if (connectionStatus) {

--- a/bridge-client/src/index.html
+++ b/bridge-client/src/index.html
@@ -64,6 +64,7 @@
             <a id="omt-runtime-link" class="network-audio-runtime-link" href="https://www.openmediatransport.org/" target="_blank" rel="noreferrer">OMT information</a>
           </div>
         </div>
+        <div class="audio-scan-status" id="audio-scan-status" role="status"></div>
         <div class="connection-error" id="announce-error" role="status"></div>
         <div class="autostart-status" id="autostart-status"></div>
       </section>

--- a/bridge-client/src/styles.css
+++ b/bridge-client/src/styles.css
@@ -701,6 +701,17 @@ ul {
   padding: 1rem;
 }
 
+.audio-scan-status {
+  color: #d8b56a;
+  font-size: 0.78rem;
+  line-height: 1.35;
+  margin-top: 0.45rem;
+}
+
+.audio-scan-status:empty {
+  display: none;
+}
+
 .muted {
   color: #81909d;
 }


### PR DESCRIPTION
## What changed

- isolate system input, system output, NDI, and OMT discovery
- skip individual devices whose format query exceeds its timeout
- quarantine unresponsive devices and backends for the current Bridge process
- allow the Bridge to announce the remaining working inventory
- render NDI and OMT status independently and show skipped-component warnings

## Why

A single unresponsive Windows audio driver could block the complete startup inventory. Because the UI awaited every native query as one group, NDI and OMT remained on `Checking…` and the Bridge never announced itself to the server.

## Impact

Working audio devices remain available even when another driver or network-audio backend hangs. Operators no longer need to disable the problematic Windows device manually.

## Validation

- Bridge frontend production build passes
- JavaScript syntax check passes
- 39 existing server tests pass
- diff whitespace check passes
- native Rust timeout unit test added; local Cargo execution was unavailable because the workstation has no Rust toolchain