### PR TITLE
Fix mediasoup worker upgrades and startup readiness

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -920,6 +920,7 @@ let micCleanupTimer = null;
 let micPrimed = false;
 let micPrimingPromise = null;
 let initialMicAccessRequested = false;
+let mediaInitialized = false;
 
 let feedStreaming = false;
 let feedManualStop = false;
@@ -3409,7 +3410,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const productionSessionSelect = document.getElementById('production-session-select');
   const mediaConnectionStatusEl = document.getElementById('media-connection-status');
   const mediaConnectionStatusLabelEl = document.getElementById('media-connection-status-label');
-  let mediaInitialized = false;
   const mediaConnectionState = {
     signaling: socket.connected ? 'connected' : 'connecting',
     send: 'idle',
@@ -9886,8 +9886,12 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
         socket.emit("get-router-rtp-capabilities", (caps) => {
           clearTimeout(timeout);
-          if (!caps) {
+          if (!caps || typeof caps !== 'object') {
             reject(new Error("No RTP capabilities received"));
+          } else if (caps.error) {
+            reject(new Error(`Server could not provide RTP capabilities: ${caps.error}`));
+          } else if (!Array.isArray(caps.codecs)) {
+            reject(new Error("Server returned invalid RTP capabilities"));
           } else {
             resolve(caps);
           }
@@ -9911,7 +9915,15 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
         socket.emit("create-send-transport", null, (params) => {
           clearTimeout(timeout);
-          resolve(params);
+          if (!params || typeof params !== 'object') {
+            reject(new Error("Server returned no send transport parameters"));
+          } else if (params.error) {
+            reject(new Error(`Server could not create send transport: ${params.error}`));
+          } else if (typeof params.id !== 'string') {
+            reject(new Error("Server returned invalid send transport parameters"));
+          } else {
+            resolve(params);
+          }
         });
       });
 
@@ -9976,7 +9988,15 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
         socket.emit("create-recv-transport", null, (params) => {
           clearTimeout(timeout);
-          resolve(params);
+          if (!params || typeof params !== 'object') {
+            reject(new Error("Server returned no receive transport parameters"));
+          } else if (params.error) {
+            reject(new Error(`Server could not create receive transport: ${params.error}`));
+          } else if (typeof params.id !== 'string') {
+            reject(new Error("Server returned invalid receive transport parameters"));
+          } else {
+            resolve(params);
+          }
         });
       });
 

--- a/runtimeWorker.js
+++ b/runtimeWorker.js
@@ -1,0 +1,53 @@
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+function fileSha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function filesMatch(sourcePath, destinationPath) {
+  if (!fs.existsSync(destinationPath)) return false;
+
+  const sourceStat = fs.statSync(sourcePath);
+  const destinationStat = fs.statSync(destinationPath);
+  if (sourceStat.size !== destinationStat.size) return false;
+
+  return fileSha256(sourcePath) === fileSha256(destinationPath);
+}
+
+function syncRuntimeExecutable(sourcePath, destinationPath) {
+  if (!sourcePath || !fs.existsSync(sourcePath)) {
+    throw new Error(`Runtime source is missing: ${sourcePath || "unknown"}`);
+  }
+
+  if (path.resolve(sourcePath) === path.resolve(destinationPath)) {
+    return { updated: false, destinationPath };
+  }
+
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  if (filesMatch(sourcePath, destinationPath)) {
+    fs.chmodSync(destinationPath, 0o755);
+    return { updated: false, destinationPath };
+  }
+
+  const temporaryPath = `${destinationPath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.copyFileSync(sourcePath, temporaryPath);
+    fs.chmodSync(temporaryPath, 0o755);
+    fs.renameSync(temporaryPath, destinationPath);
+  } catch (error) {
+    try {
+      fs.rmSync(temporaryPath, { force: true });
+    } catch {}
+    throw new Error(`Failed to update runtime executable ${destinationPath}: ${error.message}`);
+  }
+
+  return { updated: true, destinationPath };
+}
+
+module.exports = {
+  fileSha256,
+  filesMatch,
+  syncRuntimeExecutable,
+};

--- a/runtimeWorker.test.js
+++ b/runtimeWorker.test.js
@@ -1,0 +1,42 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  fileSha256,
+  syncRuntimeExecutable,
+} = require("./runtimeWorker");
+
+test("syncRuntimeExecutable replaces an outdated runtime worker", (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "talktome-runtime-worker-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+  const source = path.join(directory, "bundled-worker");
+  const destination = path.join(directory, "runtime", "mediasoup-worker");
+  fs.writeFileSync(source, "new worker");
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(destination, "old worker");
+
+  const result = syncRuntimeExecutable(source, destination);
+
+  assert.equal(result.updated, true);
+  assert.equal(fileSha256(destination), fileSha256(source));
+  assert.equal(fs.statSync(destination).mode & 0o111, 0o111);
+});
+
+test("syncRuntimeExecutable leaves an identical runtime worker in place", (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "talktome-runtime-worker-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+  const source = path.join(directory, "bundled-worker");
+  const destination = path.join(directory, "runtime", "mediasoup-worker");
+  fs.writeFileSync(source, "same worker");
+
+  const firstResult = syncRuntimeExecutable(source, destination);
+  const secondResult = syncRuntimeExecutable(source, destination);
+
+  assert.equal(firstResult.updated, true);
+  assert.equal(secondResult.updated, false);
+});

--- a/scripts/native-startup-smoke-test.mjs
+++ b/scripts/native-startup-smoke-test.mjs
@@ -217,6 +217,14 @@ async function main() {
   const localAppData = path.join(tempRoot, "local-app-data");
   await mkdir(dataDir, { recursive: true });
   await mkdir(localAppData, { recursive: true });
+  const staleRuntimeDir = path.join(dataDir, "runtime");
+  const staleWorkerName = process.platform === "win32" ? "mediasoup-worker.exe" : "mediasoup-worker";
+  const staleWorkerPath = path.join(staleRuntimeDir, staleWorkerName);
+  await mkdir(staleRuntimeDir, { recursive: true });
+  await writeFile(staleWorkerPath, "outdated mediasoup worker used to verify runtime upgrades\n");
+  if (process.platform !== "win32") {
+    await chmod(staleWorkerPath, 0o755);
+  }
   const launchedExecutable = mode === "server"
     ? await stageServerRuntime(executable, tempRoot)
     : executable;

--- a/serverCore.js
+++ b/serverCore.js
@@ -30,6 +30,7 @@ const {
 const {
   shouldCloseBridgeSessionAfterEventStreamClose,
 } = require("./bridgeSessionLiveness");
+const { syncRuntimeExecutable } = require("./runtimeWorker");
 
 const SERVER_APP_VERSION = resolveServerAppVersion();
 const CLIENT_ICE_CONFIG = resolveClientIceConfig(process.env);
@@ -72,11 +73,10 @@ if (process.pkg) {
   }
 
   const runtimeDir = path.join(getDataDir(), "runtime");
-  fs.mkdirSync(runtimeDir, { recursive: true });
   const dest = path.join(runtimeDir, workerName);
-  if (!fs.existsSync(dest)) {
-    fs.copyFileSync(sourceBin, dest);
-    fs.chmodSync(dest, 0o755);
+  const workerSync = syncRuntimeExecutable(sourceBin, dest);
+  if (workerSync.updated) {
+    console.log(`[INIT] Updated mediasoup worker runtime: ${dest}`);
   }
 
   // The packaged worker is copied out of pkg's virtual filesystem before it
@@ -6387,7 +6387,7 @@ function warnIfDockerAnnouncedIpLooksInternal(announcedIp) {
   );
 }
 
-(async () => {
+const mediaReadyPromise = (async () => {
   console.log("[INIT] Starting mediasoup worker");
   try {
     worker = await mediasoup.createWorker({
@@ -7332,6 +7332,9 @@ io.on("connection", (socket) => {
   socket.on("create-send-transport", async (_, callback) => {
     console.log(`[TRANSPORT] Client ${socket.id} requests send transport`);
     try {
+      if (!router) {
+        return callback({ error: "Media router is not ready, try again" });
+      }
       const mediaRoute = resolveTransportAnnouncedAddress();
       if (mediaRoute.error || !mediaRoute.announcedAddress) {
         console.error("[TRANSPORT] No usable announced IP:", mediaRoute.error || "unknown media network error");
@@ -7378,6 +7381,9 @@ io.on("connection", (socket) => {
   socket.on("create-recv-transport", async (_, callback) => {
     console.log(`[TRANSPORT] Client ${socket.id} requests recv transport`);
     try {
+      if (!router) {
+        return callback({ error: "Media router is not ready, try again" });
+      }
       const mediaRoute = resolveTransportAnnouncedAddress();
       if (mediaRoute.error || !mediaRoute.announcedAddress) {
         console.error("[TRANSPORT] No usable announced IP:", mediaRoute.error || "unknown media network error");
@@ -8061,7 +8067,7 @@ server.on("error", (err) => {
   process.exit(1);
 });
 
-server.listen(HTTPS_PORT, () => {
+function logHttpsServerReady() {
   const startupHosts = getStartupHosts();
   const configuredPublicIp = typeof process.env.PUBLIC_IP === "string"
     ? process.env.PUBLIC_IP.trim()
@@ -8131,4 +8137,18 @@ server.listen(HTTPS_PORT, () => {
   if (!readCompanionApiKeyFromEnv()) {
     console.log(`🔐 API key file: ${COMPANION_API_KEY_FILE}`);
   }
+}
+
+function startHttpsServer() {
+  server.listen(HTTPS_PORT, logHttpsServerReady);
+}
+
+mediaReadyPromise.then(startHttpsServer).catch((error) => {
+  const message = error?.stack || error?.message || String(error);
+  console.error(`[INIT] mediasoup initialization failed: ${message}`);
+  try {
+    worker?.close();
+  } catch {}
+  process.exitCode = 1;
+  setImmediate(() => process.exit(1));
 });


### PR DESCRIPTION
## Summary
- replace stale extracted mediasoup workers when packaged versions change
- expose HTTPS readiness only after mediasoup router initialization
- surface signaling errors in the browser and fix media initialization scope
- exercise stale-worker upgrades in native startup smoke tests

## Verification
- `npm test` (55 tests)
- Node 24 syntax checks
- macOS Node 24 package build
- packaged startup smoke test with an intentionally stale worker