### PR TITLE
Replace stale native SQLite runtimes

### DIFF
--- a/db.js
+++ b/db.js
@@ -2,14 +2,11 @@
 const fs = require("fs");
 const path = require("path");
 const Database = require("better-sqlite3");
-const { getDataFile } = require("./dataPaths");
+const { getDataDir, getDataFile } = require("./dataPaths");
+const { syncRuntimeFile } = require("./runtimeWorker");
 
 function resolveNativeBinding() {
-  if (!process.pkg) return null;
   const execDir = path.dirname(process.execPath);
-  const targetPath = path.join(execDir, "better_sqlite3.node");
-  if (fs.existsSync(targetPath)) return targetPath;
-
   const bundledPath = path.join(
     __dirname,
     "node_modules",
@@ -18,21 +15,29 @@ function resolveNativeBinding() {
     "Release",
     "better_sqlite3.node"
   );
-  if (fs.existsSync(bundledPath)) {
-    fs.copyFileSync(bundledPath, targetPath);
-    return targetPath;
+  const candidates = [
+    bundledPath,
+    path.join(execDir, "binaries", "better_sqlite3.node"),
+    path.join(execDir, "better_sqlite3.node"),
+  ];
+  const sourcePath = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!sourcePath) {
+    throw new Error(
+      `better_sqlite3.node is missing. Checked: ${candidates.join(", ")}`
+    );
   }
 
-  throw new Error(
-    "better_sqlite3.node is missing. Place it next to the executable."
-  );
+  const targetPath = path.join(getDataDir(), "runtime", "better_sqlite3.node");
+  const result = syncRuntimeFile(sourcePath, targetPath);
+  if (result.updated) {
+    console.log(`[INIT] Updated better-sqlite3 runtime: ${targetPath}`);
+  }
+  return targetPath;
 }
 
 const nativeBinding = resolveNativeBinding();
 const dbPath = getDataFile("app.db");
-const db = nativeBinding
-  ? new Database(dbPath, { nativeBinding })
-  : new Database(dbPath);
+const db = new Database(dbPath, { nativeBinding });
 
 // Initialize tables (run once)
 db.exec(`

--- a/nativeBindingRuntime.test.js
+++ b/nativeBindingRuntime.test.js
@@ -1,0 +1,38 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const { fileSha256 } = require("./runtimeWorker");
+
+test("unpackaged and Docker server replace a stale persisted SQLite binding", (t) => {
+  const dataDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "talktome-native-binding-"));
+  t.after(() => fs.rmSync(dataDirectory, { recursive: true, force: true }));
+
+  const runtimeDirectory = path.join(dataDirectory, "runtime");
+  const runtimeBinding = path.join(runtimeDirectory, "better_sqlite3.node");
+  fs.mkdirSync(runtimeDirectory, { recursive: true });
+  fs.writeFileSync(runtimeBinding, "binding compiled for an older Node ABI");
+
+  const result = spawnSync(process.execPath, ["-e", "require('./db').close()"], {
+    cwd: __dirname,
+    env: {
+      ...process.env,
+      TALKTOME_DATA_DIR: dataDirectory,
+    },
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const installedBinding = path.join(
+    __dirname,
+    "node_modules",
+    "better-sqlite3",
+    "build",
+    "Release",
+    "better_sqlite3.node"
+  );
+  assert.equal(fileSha256(runtimeBinding), fileSha256(installedBinding));
+});

--- a/runtimeWorker.js
+++ b/runtimeWorker.js
@@ -16,7 +16,7 @@ function filesMatch(sourcePath, destinationPath) {
   return fileSha256(sourcePath) === fileSha256(destinationPath);
 }
 
-function syncRuntimeExecutable(sourcePath, destinationPath) {
+function syncRuntimeFile(sourcePath, destinationPath, { executable = false } = {}) {
   if (!sourcePath || !fs.existsSync(sourcePath)) {
     throw new Error(`Runtime source is missing: ${sourcePath || "unknown"}`);
   }
@@ -27,27 +27,32 @@ function syncRuntimeExecutable(sourcePath, destinationPath) {
 
   fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
   if (filesMatch(sourcePath, destinationPath)) {
-    fs.chmodSync(destinationPath, 0o755);
+    if (executable) fs.chmodSync(destinationPath, 0o755);
     return { updated: false, destinationPath };
   }
 
   const temporaryPath = `${destinationPath}.tmp-${process.pid}-${Date.now()}`;
   try {
     fs.copyFileSync(sourcePath, temporaryPath);
-    fs.chmodSync(temporaryPath, 0o755);
+    if (executable) fs.chmodSync(temporaryPath, 0o755);
     fs.renameSync(temporaryPath, destinationPath);
   } catch (error) {
     try {
       fs.rmSync(temporaryPath, { force: true });
     } catch {}
-    throw new Error(`Failed to update runtime executable ${destinationPath}: ${error.message}`);
+    throw new Error(`Failed to update runtime file ${destinationPath}: ${error.message}`);
   }
 
   return { updated: true, destinationPath };
+}
+
+function syncRuntimeExecutable(sourcePath, destinationPath) {
+  return syncRuntimeFile(sourcePath, destinationPath, { executable: true });
 }
 
 module.exports = {
   fileSha256,
   filesMatch,
   syncRuntimeExecutable,
+  syncRuntimeFile,
 };

--- a/runtimeWorker.test.js
+++ b/runtimeWorker.test.js
@@ -7,6 +7,7 @@ const test = require("node:test");
 const {
   fileSha256,
   syncRuntimeExecutable,
+  syncRuntimeFile,
 } = require("./runtimeWorker");
 
 test("syncRuntimeExecutable replaces an outdated runtime worker", (t) => {
@@ -39,4 +40,23 @@ test("syncRuntimeExecutable leaves an identical runtime worker in place", (t) =>
 
   assert.equal(firstResult.updated, true);
   assert.equal(secondResult.updated, false);
+});
+
+test("syncRuntimeFile replaces an outdated native module without making it executable", (t) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "talktome-runtime-file-"));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+  const source = path.join(directory, "bundled", "better_sqlite3.node");
+  const destination = path.join(directory, "runtime", "better_sqlite3.node");
+  fs.mkdirSync(path.dirname(source), { recursive: true });
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.writeFileSync(source, "node 24 binding");
+  fs.writeFileSync(destination, "node 18 binding");
+  fs.chmodSync(source, 0o644);
+
+  const result = syncRuntimeFile(source, destination);
+
+  assert.equal(result.updated, true);
+  assert.equal(fileSha256(destination), fileSha256(source));
+  assert.equal(fs.statSync(destination).mode & 0o111, 0);
 });

--- a/scripts/native-startup-smoke-test.mjs
+++ b/scripts/native-startup-smoke-test.mjs
@@ -220,14 +220,22 @@ async function main() {
   const staleRuntimeDir = path.join(dataDir, "runtime");
   const staleWorkerName = process.platform === "win32" ? "mediasoup-worker.exe" : "mediasoup-worker";
   const staleWorkerPath = path.join(staleRuntimeDir, staleWorkerName);
+  const staleSqliteBindingPath = path.join(staleRuntimeDir, "better_sqlite3.node");
   await mkdir(staleRuntimeDir, { recursive: true });
   await writeFile(staleWorkerPath, "outdated mediasoup worker used to verify runtime upgrades\n");
+  await writeFile(staleSqliteBindingPath, "outdated Node 18 better-sqlite3 binding\n");
   if (process.platform !== "win32") {
     await chmod(staleWorkerPath, 0o755);
   }
   const launchedExecutable = mode === "server"
     ? await stageServerRuntime(executable, tempRoot)
     : executable;
+  if (mode === "server") {
+    await writeFile(
+      path.join(path.dirname(launchedExecutable), "better_sqlite3.node"),
+      "outdated Node 18 binding left beside the upgraded server executable\n"
+    );
+  }
 
   if (mode === "server" && expectedVersion) {
     verifyPackagedServerVersion(launchedExecutable, expectedVersion);


### PR DESCRIPTION
## Summary
- synchronize the current better-sqlite3 native binding into the persistent runtime directory
- replace stale Node ABI bindings by checksum on Windows, macOS, Linux and Docker
- stop preferring an outdated binding beside the packaged executable
- extend native startup smoke coverage for Node 18 to Node 24 upgrades

## Verification
- `npm test` (57 tests)
- Node 24 package build
- packaged startup smoke test with stale worker and SQLite bindings
- unpackaged/Docker-style persisted runtime test