### PR TITLE
Fix Windows Bridge device recovery

### DIFF
--- a/bridge-client/src-tauri/src/audio.rs
+++ b/bridge-client/src-tauri/src/audio.rs
@@ -1,7 +1,7 @@
 use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::{Device, SampleRate, SupportedBufferSize, SupportedStreamConfigRange};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::{mpsc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -61,12 +61,64 @@ pub struct AudioDeviceSnapshotEntry {
 
 const DEVICE_DETAILS_TIMEOUT: Duration = Duration::from_secs(2);
 const SYSTEM_DIRECTION_TIMEOUT: Duration = Duration::from_secs(4);
+const PROBE_RETRY_COOLDOWN: Duration = Duration::from_secs(30);
 
 // Native driver calls cannot be cancelled safely. A timed-out worker is left
-// detached, and these sets prevent another worker from entering the same bad
-// driver path during the current process lifetime.
-static TIMED_OUT_DEVICE_PROBES: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-static TIMED_OUT_DIRECTIONS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+// detached, so retries are delayed. The quarantine uses stable endpoint IDs and
+// is cleared when the lightweight snapshot observes a topology change.
+static TIMED_OUT_DEVICE_PROBES: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+static TIMED_OUT_DIRECTIONS: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+static LAST_SYSTEM_DEVICE_SNAPSHOT: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+
+fn is_probe_quarantined(quarantine: &Mutex<HashMap<String, Instant>>, key: &str) -> bool {
+    let Ok(mut entries) = quarantine.lock() else {
+        return false;
+    };
+    let Some(timed_out_at) = entries.get(key).copied() else {
+        return false;
+    };
+    if timed_out_at.elapsed() < PROBE_RETRY_COOLDOWN {
+        return true;
+    }
+    entries.remove(key);
+    false
+}
+
+fn quarantine_probe(quarantine: &Mutex<HashMap<String, Instant>>, key: String) {
+    if let Ok(mut entries) = quarantine.lock() {
+        entries.insert(key, Instant::now());
+    }
+}
+
+fn clear_probe_quarantines() {
+    if let Some(quarantine) = TIMED_OUT_DEVICE_PROBES.get() {
+        if let Ok(mut entries) = quarantine.lock() {
+            entries.clear();
+        }
+    }
+    if let Some(quarantine) = TIMED_OUT_DIRECTIONS.get() {
+        if let Ok(mut entries) = quarantine.lock() {
+            entries.clear();
+        }
+    }
+}
+
+fn update_system_device_snapshot(devices: &[AudioDeviceSnapshotEntry]) {
+    let mut identities = devices
+        .iter()
+        .map(|device| format!("{}:{}", device.direction, device.id))
+        .collect::<Vec<_>>();
+    identities.sort();
+    let signature = identities.join("\n");
+    let snapshots = LAST_SYSTEM_DEVICE_SNAPSHOT.get_or_init(|| Mutex::new(None));
+    let Ok(mut previous) = snapshots.lock() else {
+        return;
+    };
+    if previous.as_ref() != Some(&signature) {
+        clear_probe_quarantines();
+        *previous = Some(signature);
+    }
+}
 
 pub fn list_audio_devices() -> Result<AudioInventory, String> {
     let host = cpal::default_host();
@@ -98,11 +150,8 @@ struct SystemDirectionProbe {
 
 fn spawn_system_direction_probe(host_name: String, direction: &'static str) -> SystemDirectionProbe {
     let probe_key = format!("{host_name}:{direction}");
-    let timed_out = TIMED_OUT_DIRECTIONS.get_or_init(|| Mutex::new(HashSet::new()));
-    if timed_out
-        .lock()
-        .is_ok_and(|directions| directions.contains(&probe_key))
-    {
+    let timed_out = TIMED_OUT_DIRECTIONS.get_or_init(|| Mutex::new(HashMap::new()));
+    if is_probe_quarantined(timed_out, &probe_key) {
         return SystemDirectionProbe {
             direction,
             probe_key,
@@ -162,7 +211,7 @@ fn collect_system_direction_probe(
     devices: &mut Vec<AudioDeviceInfo>,
     warnings: &mut Vec<String>,
 ) {
-    let timed_out = TIMED_OUT_DIRECTIONS.get_or_init(|| Mutex::new(HashSet::new()));
+    let timed_out = TIMED_OUT_DIRECTIONS.get_or_init(|| Mutex::new(HashMap::new()));
     let Some(receiver) = probe.receiver else {
         warnings.push(format!(
             "Skipped all system audio {}s: device enumeration stopped responding earlier.",
@@ -177,9 +226,7 @@ fn collect_system_direction_probe(
             warnings.append(&mut skipped);
         }
         Err(error) => {
-            if let Ok(mut directions) = timed_out.lock() {
-                directions.insert(probe.probe_key);
-            }
+            quarantine_probe(timed_out, probe.probe_key);
             let reason = match error {
                 mpsc::RecvTimeoutError::Timeout => format!(
                     "device enumeration did not respond within {} seconds",
@@ -203,16 +250,13 @@ fn describe_devices_with_timeout(
     devices: impl Iterator<Item = (usize, Device)>,
     default_name: Option<&str>,
 ) -> (Vec<AudioDeviceInfo>, Vec<String>) {
-    let timed_out = TIMED_OUT_DEVICE_PROBES.get_or_init(|| Mutex::new(HashSet::new()));
+    let timed_out = TIMED_OUT_DEVICE_PROBES.get_or_init(|| Mutex::new(HashMap::new()));
     let mut pending = Vec::new();
     let mut warnings = Vec::new();
 
     for (index, device) in devices {
-        let probe_key = format!("{host_name}:{direction}:{index}");
-        if timed_out
-            .lock()
-            .is_ok_and(|probes| probes.contains(&probe_key))
-        {
+        let probe_key = device_probe_key(host_name, direction, index, &device);
+        if is_probe_quarantined(timed_out, &probe_key) {
             warnings.push(format!(
                 "Skipped {direction} audio device #{index}: its driver stopped responding earlier."
             ));
@@ -246,18 +290,14 @@ fn describe_devices_with_timeout(
                 "Skipped {direction} audio device #{index}: {error}"
             )),
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                if let Ok(mut probes) = timed_out.lock() {
-                    probes.insert(probe_key);
-                }
+                quarantine_probe(timed_out, probe_key);
                 warnings.push(format!(
                     "Skipped {direction} audio device #{index}: its driver did not respond within {} seconds.",
                     DEVICE_DETAILS_TIMEOUT.as_secs()
                 ));
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                if let Ok(mut probes) = timed_out.lock() {
-                    probes.insert(probe_key);
-                }
+                quarantine_probe(timed_out, probe_key);
                 warnings.push(format!(
                     "Skipped {direction} audio device #{index}: its driver probe stopped unexpectedly."
                 ));
@@ -308,6 +348,8 @@ pub fn list_audio_device_snapshot() -> Result<AudioDeviceSnapshot, String> {
         }
         Err(err) => eprintln!("failed to enumerate output devices: {err}"),
     }
+
+    update_system_device_snapshot(&devices);
 
     devices.extend(network_audio::audio_device_snapshot(Duration::from_millis(
         100,
@@ -419,6 +461,13 @@ fn device_id_for(host_name: &str, direction: &str, index: usize, device: &Device
         .unwrap_or_else(|_| {
             stable_enough_device_id(host_name, direction, index, &device.to_string())
         })
+}
+
+fn device_probe_key(host_name: &str, direction: &str, index: usize, device: &Device) -> String {
+    device
+        .id()
+        .map(|native_id| format!("{host_name}:{direction}:{native_id:?}"))
+        .unwrap_or_else(|_| format!("{host_name}:{direction}:fallback-index:{index}"))
 }
 
 fn supported_configs_for(

--- a/bridge-client/src-tauri/src/bridge_media.rs
+++ b/bridge-client/src-tauri/src/bridge_media.rs
@@ -16,7 +16,8 @@ use std::os::windows::process::CommandExt;
 
 use cpal::traits::{DeviceTrait, StreamTrait};
 use cpal::{
-    SampleFormat, SampleRate, Stream, StreamConfig, SupportedStreamConfigRange, SAMPLE_RATE_48K,
+    ErrorKind, SampleFormat, SampleRate, Stream, StreamConfig, SupportedStreamConfigRange,
+    SAMPLE_RATE_48K,
 };
 use serde::{Deserialize, Serialize};
 
@@ -222,6 +223,7 @@ pub struct BridgeMediaInputStats {
     pub stream_id: String,
     pub rms_db: f32,
     pub captured_frames: u64,
+    pub xrun_count: u64,
     pub dropped_chunks: u64,
     pub dropped_frames: u64,
     pub ffmpeg_warning_count: u64,
@@ -281,6 +283,7 @@ struct BridgeInputRuntime {
     last_error: Arc<Mutex<Option<String>>>,
     level_milli_db: Arc<AtomicI32>,
     captured_frames: Arc<AtomicU64>,
+    xrun_count: Arc<AtomicU64>,
     dropped_chunks: Arc<AtomicU64>,
     dropped_frames: Arc<AtomicU64>,
     ffmpeg_warning_count: Arc<AtomicU64>,
@@ -591,6 +594,8 @@ impl BridgeInputRuntime {
         let callback_level = Arc::clone(&level_milli_db);
         let captured_frames = Arc::new(AtomicU64::new(0));
         let callback_captured_frames = Arc::clone(&captured_frames);
+        let xrun_count = Arc::new(AtomicU64::new(0));
+        let callback_xrun_count = Arc::clone(&xrun_count);
         let dropped_chunks = Arc::new(AtomicU64::new(0));
         let callback_dropped_chunks = Arc::clone(&dropped_chunks);
         let dropped_frames = Arc::new(AtomicU64::new(0));
@@ -659,7 +664,14 @@ impl BridgeInputRuntime {
                         },
                         move |err| {
                             let message = format!("bridge input stream error: {err}");
-                            eprintln!("{message}");
+                            if is_recoverable_stream_error(err.kind()) {
+                                if matches!(err.kind(), ErrorKind::Xrun) {
+                                    callback_xrun_count.fetch_add(1, Ordering::Relaxed);
+                                }
+                                eprintln!("[bridge-media][input][recoverable] {message}");
+                                return;
+                            }
+                            eprintln!("[bridge-media][input][fatal] {message}");
                             if let Ok(mut last_error) = stream_error.lock() {
                                 *last_error = Some(message);
                             }
@@ -747,6 +759,7 @@ impl BridgeInputRuntime {
             last_error,
             level_milli_db,
             captured_frames,
+            xrun_count,
             dropped_chunks,
             dropped_frames,
             ffmpeg_warning_count,
@@ -860,7 +873,11 @@ impl BridgeOutputMixerRuntime {
                     },
                     move |err| {
                         let message = format!("bridge output stream error: {err}");
-                        eprintln!("{message}");
+                        if is_recoverable_stream_error(err.kind()) {
+                            eprintln!("[bridge-media][output][recoverable] {message}");
+                            return;
+                        }
+                        eprintln!("[bridge-media][output][fatal] {message}");
                         if let Ok(mut last_error) = stream_error.lock() {
                             *last_error = Some(message);
                         }
@@ -1234,6 +1251,13 @@ fn validate_stream_id(stream_id: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn is_recoverable_stream_error(kind: ErrorKind) -> bool {
+    matches!(
+        kind,
+        ErrorKind::Xrun | ErrorKind::RealtimeDenied | ErrorKind::DeviceChanged
+    )
+}
+
 fn validate_assignment(assignment: &BridgeChannelAssignment, label: &str) -> Result<(), String> {
     if assignment.device_id.trim().is_empty() {
         return Err(format!("{label} device is required"));
@@ -1287,6 +1311,7 @@ fn status_from(state: &BridgeMediaState) -> BridgeMediaStatus {
             stream_id: stream_id.clone(),
             rms_db: runtime.level_milli_db.load(Ordering::Relaxed) as f32 / 1000.0,
             captured_frames: runtime.captured_frames.load(Ordering::Relaxed),
+            xrun_count: runtime.xrun_count.load(Ordering::Relaxed),
             dropped_chunks: runtime.dropped_chunks.load(Ordering::Relaxed),
             dropped_frames: runtime.dropped_frames.load(Ordering::Relaxed),
             ffmpeg_warning_count: runtime.ffmpeg_warning_count.load(Ordering::Relaxed),
@@ -1345,6 +1370,15 @@ fn read_last_error(last_error: &Arc<Mutex<Option<String>>>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn only_non_fatal_stream_notifications_are_recoverable() {
+        assert!(is_recoverable_stream_error(ErrorKind::Xrun));
+        assert!(is_recoverable_stream_error(ErrorKind::RealtimeDenied));
+        assert!(is_recoverable_stream_error(ErrorKind::DeviceChanged));
+        assert!(!is_recoverable_stream_error(ErrorKind::StreamInvalidated));
+        assert!(!is_recoverable_stream_error(ErrorKind::DeviceNotAvailable));
+    }
 
     #[test]
     fn builds_minimal_rtcp_receiver_report() {

--- a/bridge-client/src/app.js
+++ b/bridge-client/src/app.js
@@ -38,7 +38,8 @@ const STORAGE_KEYS = {
 const MANAGED_EVENT_FALLBACK_POLL_MS = 250;
 // This timer only reads the lightweight device snapshot. Full format discovery
 // runs at startup, on manual refresh, or after the snapshot actually changes.
-const MANAGED_INVENTORY_WATCH_MS = 30_000;
+const MANAGED_INVENTORY_WATCH_MS = 5_000;
+const MANAGED_INVENTORY_RETRY_MS = 30_000;
 const MANAGED_RETRY_MS = 2_000;
 const MANAGED_LEVEL_TRIGGER_POLL_MS = 50;
 const MANAGED_LEVEL_TRIGGER_ATTACK_MS = 45;
@@ -75,7 +76,7 @@ let managedLevelTriggerTimer = null;
 let managedRetryRunning = false;
 let managedLevelTriggerRunning = false;
 let managedInventoryWatchRunning = false;
-let managedInventoryWatchDisabled = false;
+let managedInventoryWatchRetryAt = 0;
 let managedRangeInteractionActive = false;
 let lastAnnouncedInventorySignature = "";
 let lastAudioDeviceSnapshotSignature = "";
@@ -1366,7 +1367,13 @@ function finishManagedRangeInteraction() {
 }
 
 function renderManagedBridgePorts() {
-  if (managedRangeInteractionActive) return;
+  const activeElement = document.activeElement;
+  const managedControlFocused = (
+    activeElement instanceof HTMLElement
+    && bridgePorts?.contains(activeElement)
+    && activeElement.matches("select, input, textarea")
+  );
+  if (managedRangeInteractionActive || managedControlFocused) return;
   const configuredPorts = managedBridgeConfig?.ports ?? [];
   if (!managedBridgeConfig) {
     const html = '<div class="empty-state">Connect to the server to load bridge endpoints.</div>';
@@ -2654,7 +2661,7 @@ async function refreshManagedInventoryOnly() {
     AUDIO_INVENTORY_TIMEOUT_MS,
     "Audio device scan"
   );
-  managedInventoryWatchDisabled = false;
+  managedInventoryWatchRetryAt = 0;
   renderInventory(inventory);
   const [ndiResult, omtResult] = await Promise.allSettled([
     withTimeout(invoke("get_ndi_status"), AUDIO_STATUS_TIMEOUT_MS, "NDI status check"),
@@ -2767,7 +2774,12 @@ async function syncManagedBridge() {
 }
 
 async function watchManagedInventory() {
-  if (managedInventoryWatchRunning || managedInventoryWatchDisabled || managedSyncRunning || !invoke) return;
+  if (
+    managedInventoryWatchRunning
+    || managedSyncRunning
+    || !invoke
+    || Date.now() < managedInventoryWatchRetryAt
+  ) return;
   if (isBridgeSettingsControlFocused()) return;
   if (!serverUrlInput.value.trim() || !getBridgeCredential()) return;
 
@@ -2779,6 +2791,7 @@ async function watchManagedInventory() {
       "Audio device snapshot"
     );
     const nextSnapshotSignature = audioDeviceSnapshotSignature(snapshot);
+    managedInventoryWatchRetryAt = 0;
     if (!lastAudioDeviceSnapshotSignature) {
       lastAudioDeviceSnapshotSignature = nextSnapshotSignature;
     } else if (nextSnapshotSignature && nextSnapshotSignature !== lastAudioDeviceSnapshotSignature) {
@@ -2795,7 +2808,7 @@ async function watchManagedInventory() {
   } catch (error) {
     console.warn("managed inventory watch failed", error);
     if (/audio device snapshot did not respond/i.test(String(error?.message || error))) {
-      managedInventoryWatchDisabled = true;
+      managedInventoryWatchRetryAt = Date.now() + MANAGED_INVENTORY_RETRY_MS;
     }
   } finally {
     managedInventoryWatchRunning = false;
@@ -3367,7 +3380,16 @@ function renderAllPortControls() {
     return;
   }
 
-  portRows.forEach((row) => populatePortControls(row));
+  portRows.forEach((row) => {
+    const activeElement = document.activeElement;
+    const rowControlFocused = (
+      activeElement instanceof HTMLElement
+      && row.element?.contains(activeElement)
+      && activeElement.matches("select, input, textarea")
+    );
+    if (rowControlFocused) return;
+    populatePortControls(row);
+  });
 }
 
 function updatePortControlState(row) {
@@ -3564,7 +3586,7 @@ async function refreshDevices() {
       ? inventoryResult[0].value
       : { host: "Unavailable", devices: [], warnings: [String(inventoryResult[0].reason)] };
     if (inventoryResult[0].status === "fulfilled") {
-      managedInventoryWatchDisabled = false;
+      managedInventoryWatchRetryAt = 0;
     }
     renderInventory(inventory);
 


### PR DESCRIPTION
## Summary
- detect newly connected Windows audio devices within five seconds and safely retry timed-out probes
- preserve focused device dropdowns during periodic UI refreshes
- treat CPAL WASAPI xruns as recoverable instead of disabling the input stream

## Validation
- npm --prefix bridge-client run build:ui
- node --check bridge-client/src/app.js
- git diff --check
- Rust classification regression test added; local Cargo toolchain unavailable