### PR TITLE
Use shareable interface URL for login links

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -3338,7 +3338,8 @@ window.copyUserLoginUrl = async function (userId, userName, button) {
       throw new Error(payload.error || 'Failed to create login URL');
     }
 
-    const loginUrl = `${window.location.origin}/#login=${encodeURIComponent(payload.token)}`;
+    const loginUrl = payload.loginUrl
+      || `${window.location.origin}/#login=${encodeURIComponent(payload.token)}`;
     await copyTextToClipboard(loginUrl);
     if (button) button.textContent = 'Copied';
     showMessage(`✅ Login URL copied for ${userName}`, 'success', 'user');

--- a/qrConnectUrl.js
+++ b/qrConnectUrl.js
@@ -44,7 +44,15 @@ function selectAdminQrUrl({ configuredUrl, requestUrl, adapterUrl } = {}) {
   return adapter || requested;
 }
 
+function buildLoginUrl(connectUrl, token) {
+  const normalized = normalizeConnectUrl(connectUrl);
+  const normalizedToken = typeof token === "string" ? token.trim() : "";
+  if (!normalized || !normalizedToken) return "";
+  return `${normalized}/#login=${encodeURIComponent(normalizedToken)}`;
+}
+
 module.exports = {
+  buildLoginUrl,
   isLocalOnlyConnectUrl,
   normalizeConnectUrl,
   selectAdminQrUrl,

--- a/qrConnectUrl.test.js
+++ b/qrConnectUrl.test.js
@@ -1,6 +1,6 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { selectAdminQrUrl } = require("./qrConnectUrl");
+const { buildLoginUrl, selectAdminQrUrl } = require("./qrConnectUrl");
 
 test("prefers the selected adapter over a localhost admin URL", () => {
   assert.equal(selectAdminQrUrl({
@@ -42,4 +42,16 @@ test("falls back to localhost when no adapter address is available", () => {
   assert.equal(selectAdminQrUrl({
     requestUrl: "https://localhost:8444",
   }), "https://localhost:8444");
+});
+
+test("builds a shareable login URL from the selected adapter URL", () => {
+  assert.equal(
+    buildLoginUrl("https://192.168.178.166:8444", "token/value"),
+    "https://192.168.178.166:8444/#login=token%2Fvalue"
+  );
+});
+
+test("does not build a login URL without a usable base URL or token", () => {
+  assert.equal(buildLoginUrl("", "token"), "");
+  assert.equal(buildLoginUrl("https://192.168.178.166:8444", ""), "");
 });

--- a/serverCore.js
+++ b/serverCore.js
@@ -14,7 +14,7 @@ const { createBrowserSessionStore } = require("./browserSessions");
 const { loadProxySsoConfig, resolveProxySsoIdentity } = require("./proxySso");
 const { getDataDir } = require("./dataPaths");
 const { ApplePttPushService } = require("./applePttPushService");
-const { normalizeConnectUrl, selectAdminQrUrl } = require("./qrConnectUrl");
+const { buildLoginUrl, normalizeConnectUrl, selectAdminQrUrl } = require("./qrConnectUrl");
 const { buildWebRtcListenInfos, resolveClientIceConfig } = require("./webrtcConfig");
 const {
   listMediaNetworkInterfaces,
@@ -3533,15 +3533,10 @@ function resolvePreferredAdminQrIpAddress(activeAddress) {
 }
 
 async function buildAdminMediaNetworkQrPayload(activeAddress, req = null) {
-  const qrIpAddress = resolvePreferredAdminQrIpAddress(activeAddress);
+  const qrUrl = resolveAdminConnectUrl(activeAddress, req);
   const configuredPublicConnectUrl = resolveConfiguredAdminPublicConnectUrl();
   const requestConnectUrl = resolveAdminRequestConnectUrl(req);
-  const adapterConnectUrl = buildHttpsConnectUrl(qrIpAddress);
-  const qrUrl = selectAdminQrUrl({
-    configuredUrl: configuredPublicConnectUrl,
-    requestUrl: requestConnectUrl,
-    adapterUrl: adapterConnectUrl,
-  });
+  const qrIpAddress = resolvePreferredAdminQrIpAddress(activeAddress);
   const publicConnectUrl = configuredPublicConnectUrl || requestConnectUrl;
   const activeMdnsHost = mdnsHostname || "off";
   const mdnsUrl = mdnsHostname ? buildHttpsConnectUrl(mdnsHostname) : "";
@@ -3572,6 +3567,18 @@ async function buildAdminMediaNetworkQrPayload(activeAddress, req = null) {
     mdnsUrl: mdnsUrl || null,
     qrCodeDataUrl,
   };
+}
+
+function resolveAdminConnectUrl(activeAddress, req = null) {
+  const qrIpAddress = resolvePreferredAdminQrIpAddress(activeAddress);
+  const configuredPublicConnectUrl = resolveConfiguredAdminPublicConnectUrl();
+  const requestConnectUrl = resolveAdminRequestConnectUrl(req);
+  const adapterConnectUrl = buildHttpsConnectUrl(qrIpAddress);
+  return selectAdminQrUrl({
+    configuredUrl: configuredPublicConnectUrl,
+    requestUrl: requestConnectUrl,
+    adapterUrl: adapterConnectUrl,
+  });
 }
 
 app.get("/admin/settings/media-network", requireAdmin, async (req, res) => {
@@ -4003,8 +4010,11 @@ app.put("/admin/users/:id/admin", requireAdmin, (req, res) => {
 app.post("/admin/users/:id/login-link", requireAdmin, (req, res) => {
   try {
     const token = createUserLoginToken(req.params.id);
+    const active = resolveTransportAnnouncedAddress();
+    const connectUrl = resolveAdminConnectUrl(active.announcedAddress, req);
+    const loginUrl = buildLoginUrl(connectUrl, token);
     res.setHeader("Cache-Control", "no-store");
-    return res.json({ token });
+    return res.json({ token, loginUrl: loginUrl || null });
   } catch (err) {
     const status = err.message === "User not found" ? 404 : 400;
     return res.status(status).json({ error: err.message || "Failed to create login link" });


### PR DESCRIPTION
## Summary
- generate user login links from the selected network interface address
- preserve configured public and reverse-proxy URLs
- reuse the server-selected URL in the admin UI

## Tests
- `node --test qrConnectUrl.test.js`
- `node --check serverCore.js`
- `node --check public/admin.js`
- `git diff --check`

The complete local suite was also run, but two existing native SQLite tests require Node 24 while the currently active local runtime is Node 20.