### PR TITLE
Add configurable client defaults and multi-target locks

### DIFF
--- a/defaultClientSettings.js
+++ b/defaultClientSettings.js
@@ -1,0 +1,72 @@
+const AUDIO_PROFILES = Object.freeze(["ultra-low", "low", "standard"]);
+const DIM_AMOUNT_DB_OPTIONS = Object.freeze([-6, -12, -14, -18, -24]);
+
+const BUILTIN_DEFAULT_CLIENT_SETTINGS = Object.freeze({
+  audioProfile: "ultra-low",
+  dimAmountDb: -14,
+  dimFeedsWhileSpeaking: false,
+  dimWhenAddressed: true,
+  audioAutoProcessing: false,
+  leftHandMode: false,
+  lockMultipleTargets: false,
+});
+
+const DEFAULT_CLIENT_SETTING_KEYS = Object.freeze(Object.keys(BUILTIN_DEFAULT_CLIENT_SETTINGS));
+
+function normalizeConfiguredDefaultClientSettings(value, { strict = false } = {}) {
+  if (value === undefined || value === null) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    if (strict) throw new Error("Default client settings must be an object.");
+    return {};
+  }
+
+  const normalized = {};
+  const reject = (message) => {
+    if (strict) throw new Error(message);
+  };
+
+  if (Object.prototype.hasOwnProperty.call(value, "audioProfile")) {
+    if (AUDIO_PROFILES.includes(value.audioProfile)) normalized.audioProfile = value.audioProfile;
+    else reject("Invalid default audio profile.");
+  }
+
+  if (Object.prototype.hasOwnProperty.call(value, "dimAmountDb")) {
+    const dimAmountDb = Number(value.dimAmountDb);
+    if (DIM_AMOUNT_DB_OPTIONS.includes(dimAmountDb)) normalized.dimAmountDb = dimAmountDb;
+    else reject("Invalid default dim amount.");
+  }
+
+  for (const key of DEFAULT_CLIENT_SETTING_KEYS.filter((entry) => (
+    entry !== "audioProfile" && entry !== "dimAmountDb"
+  ))) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+    if (typeof value[key] === "boolean") normalized[key] = value[key];
+    else reject(`Invalid boolean value for ${key}.`);
+  }
+
+  return normalized;
+}
+
+function resolveDefaultClientSettings(value) {
+  return {
+    ...BUILTIN_DEFAULT_CLIENT_SETTINGS,
+    ...normalizeConfiguredDefaultClientSettings(value),
+  };
+}
+
+function serializeDefaultClientSettingsScript(value) {
+  const json = JSON.stringify(normalizeConfiguredDefaultClientSettings(value))
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+  return `window.TALKTOME_DEFAULT_CLIENT_SETTINGS = ${json};\n`;
+}
+
+module.exports = {
+  AUDIO_PROFILES,
+  DIM_AMOUNT_DB_OPTIONS,
+  BUILTIN_DEFAULT_CLIENT_SETTINGS,
+  normalizeConfiguredDefaultClientSettings,
+  resolveDefaultClientSettings,
+  serializeDefaultClientSettingsScript,
+};

--- a/defaultClientSettings.test.js
+++ b/defaultClientSettings.test.js
@@ -1,0 +1,48 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  BUILTIN_DEFAULT_CLIENT_SETTINGS,
+  normalizeConfiguredDefaultClientSettings,
+  resolveDefaultClientSettings,
+  serializeDefaultClientSettingsScript,
+} = require("./defaultClientSettings");
+
+test("resolves built-in client defaults when no server settings exist", () => {
+  assert.deepEqual(resolveDefaultClientSettings(null), BUILTIN_DEFAULT_CLIENT_SETTINGS);
+});
+
+test("keeps only valid configured client defaults", () => {
+  assert.deepEqual(normalizeConfiguredDefaultClientSettings({
+    audioProfile: "standard",
+    dimAmountDb: -18,
+    dimFeedsWhileSpeaking: true,
+    unknown: "ignored",
+  }), {
+    audioProfile: "standard",
+    dimAmountDb: -18,
+    dimFeedsWhileSpeaking: true,
+  });
+});
+
+test("rejects invalid admin client defaults in strict mode", () => {
+  assert.throws(
+    () => normalizeConfiguredDefaultClientSettings({ audioProfile: "studio" }, { strict: true }),
+    /Invalid default audio profile/
+  );
+  assert.throws(
+    () => normalizeConfiguredDefaultClientSettings({ leftHandMode: "yes" }, { strict: true }),
+    /Invalid boolean value/
+  );
+});
+
+test("serializes client defaults as a safe browser script", () => {
+  const script = serializeDefaultClientSettingsScript({
+    audioProfile: "low",
+    lockMultipleTargets: true,
+  });
+  assert.equal(
+    script,
+    'window.TALKTOME_DEFAULT_CLIENT_SETTINGS = {"audioProfile":"low","lockMultipleTargets":true};\n'
+  );
+});

--- a/public/admin.html
+++ b/public/admin.html
@@ -715,9 +715,12 @@
         grid-column: 1 / -1;
       }
 
-      .bridge-config-form .toggle-row {
+      .bridge-config-form .bridge-input-switch {
         grid-column: 1 / -1;
         margin: 0;
+        min-height: var(--control-height);
+        color: var(--text);
+        font-weight: 600;
       }
 
       .bridge-config-options {
@@ -837,6 +840,53 @@
 
       .config-panel > h3 + .setting-meta {
         margin-top: auto;
+      }
+
+      .default-client-settings-panel {
+        grid-column: 1 / -1;
+      }
+
+      .default-client-settings-form {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .default-client-settings-selects,
+      .default-client-settings-toggles {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.75rem 1rem;
+      }
+
+      .default-client-setting-field {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .default-client-setting-field > label,
+      .default-client-setting-toggle > span:first-child {
+        color: var(--text);
+        font-size: 0.9rem;
+        font-weight: 600;
+      }
+
+      .default-client-setting-toggle {
+        min-height: 2.2rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        border-radius: 8px;
+        padding: 0.55rem 0.7rem;
+        cursor: pointer;
+      }
+
+      .default-client-settings-actions {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        min-height: 2.2rem;
       }
 
       .config-panel input:not([type='file']):not([type='checkbox']),
@@ -1063,7 +1113,7 @@
         margin-bottom: 0;
       }
 
-      .guest-login-switch {
+      .admin-switch {
         position: relative;
         display: inline-flex;
         align-items: center;
@@ -1073,7 +1123,7 @@
         user-select: none;
       }
 
-      .guest-login-switch input {
+      .admin-switch input {
         position: absolute;
         width: 1px;
         height: 1px;
@@ -1083,7 +1133,7 @@
         pointer-events: none;
       }
 
-      .guest-login-switch__track {
+      .admin-switch__track {
         position: relative;
         width: 2.8rem;
         height: 1.5rem;
@@ -1094,7 +1144,7 @@
         transition: border-color 0.15s ease, background 0.15s ease;
       }
 
-      .guest-login-switch__track::after {
+      .admin-switch__track::after {
         content: '';
         position: absolute;
         top: 0.17rem;
@@ -1107,40 +1157,40 @@
         transition: transform 0.15s ease, background 0.15s ease;
       }
 
-      .guest-login-switch__state {
+      .admin-switch__state {
         min-width: 1.7rem;
         color: var(--muted);
         font-size: 0.8rem;
         font-weight: 700;
       }
 
-      .guest-login-switch__state::before {
+      .admin-switch__state::before {
         content: 'Off';
       }
 
-      .guest-login-switch input:checked + .guest-login-switch__track {
+      .admin-switch input:checked + .admin-switch__track {
         border-color: rgba(59, 130, 246, 0.75);
         background: rgba(37, 99, 235, 0.75);
       }
 
-      .guest-login-switch input:checked + .guest-login-switch__track::after {
+      .admin-switch input:checked + .admin-switch__track::after {
         background: #fff;
         transform: translateX(1.3rem);
       }
 
-      .guest-login-switch input:checked ~ .guest-login-switch__state {
+      .admin-switch input:checked ~ .admin-switch__state {
         color: var(--text);
       }
 
-      .guest-login-switch input:checked ~ .guest-login-switch__state::before {
+      .admin-switch input:checked ~ .admin-switch__state::before {
         content: 'On';
       }
 
-      .guest-login-switch input:focus-visible + .guest-login-switch__track {
+      .admin-switch input:focus-visible + .admin-switch__track {
         box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
       }
 
-      .guest-login-switch:has(input:disabled) {
+      .admin-switch:has(input:disabled) {
         cursor: wait;
         opacity: 0.6;
       }
@@ -1196,6 +1246,16 @@
         }
 
         .config-layout > .config-panel:nth-of-type(6) {
+          grid-column: 2;
+          grid-row: 4;
+        }
+
+        .config-layout > .default-client-settings-panel {
+          grid-column: 1 / -1;
+          grid-row: auto;
+        }
+
+        #container-restart-panel.is-hidden ~ .config-backup-panel {
           grid-column: 2;
           grid-row: 4;
         }
@@ -2473,6 +2533,15 @@
           grid-template-columns: 1fr;
         }
 
+        .default-client-settings-selects,
+        .default-client-settings-toggles {
+          grid-template-columns: 1fr;
+        }
+
+        .default-client-settings-actions {
+          justify-content: stretch;
+        }
+
         #media-network-form {
           grid-template-columns: 1fr;
         }
@@ -3241,11 +3310,11 @@
                 </div>
 
                 <form id="guest-login-form" class="guest-login-form" autocomplete="off">
-                  <label class="guest-login-switch" for="guest-login-enabled">
+                  <label class="admin-switch" for="guest-login-enabled">
                     <span class="visually-hidden">Allow passwordless Guest login</span>
                     <input type="checkbox" id="guest-login-enabled" role="switch" />
-                    <span class="guest-login-switch__track" aria-hidden="true"></span>
-                    <span class="guest-login-switch__state" aria-hidden="true"></span>
+                    <span class="admin-switch__track" aria-hidden="true"></span>
+                    <span class="admin-switch__state" aria-hidden="true"></span>
                   </label>
                 </form>
               </div>
@@ -3303,7 +3372,87 @@
               <button type="button" id="container-restart-btn" class="warning">Restart server</button>
             </section>
 
-            <section class="config-panel" aria-labelledby="config-backup-heading">
+            <section class="config-panel default-client-settings-panel" aria-labelledby="config-default-client-heading">
+              <h3 id="config-default-client-heading">Default client settings</h3>
+
+              <div class="setting-meta">
+                <div>These values apply when a client has no personal setting saved yet; existing and future personal client choices continue to take precedence.</div>
+              </div>
+
+              <form id="default-client-settings-form" class="default-client-settings-form" autocomplete="off">
+                <div class="default-client-settings-selects">
+                  <div class="default-client-setting-field">
+                    <label for="default-client-audio-profile">Audio profile</label>
+                    <select id="default-client-audio-profile">
+                      <option value="ultra-low">Ultra low (5 ms frame)</option>
+                      <option value="low">Low (10 ms frame)</option>
+                      <option value="standard">Standard (20 ms frame)</option>
+                    </select>
+                  </div>
+                  <div class="default-client-setting-field">
+                    <label for="default-client-dim-amount">Dim amount</label>
+                    <select id="default-client-dim-amount">
+                      <option value="-6">-6 dB</option>
+                      <option value="-12">-12 dB</option>
+                      <option value="-14">-14 dB</option>
+                      <option value="-18">-18 dB</option>
+                      <option value="-24">-24 dB</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div class="default-client-settings-toggles">
+                  <label class="default-client-setting-toggle">
+                    <span>Dim feeds while speaking</span>
+                    <span class="admin-switch">
+                      <input type="checkbox" id="default-client-dim-self" role="switch" />
+                      <span class="admin-switch__track" aria-hidden="true"></span>
+                      <span class="admin-switch__state" aria-hidden="true"></span>
+                    </span>
+                  </label>
+                  <label class="default-client-setting-toggle">
+                    <span>Dim when addressed</span>
+                    <span class="admin-switch">
+                      <input type="checkbox" id="default-client-dim-incoming" role="switch" />
+                      <span class="admin-switch__track" aria-hidden="true"></span>
+                      <span class="admin-switch__state" aria-hidden="true"></span>
+                    </span>
+                  </label>
+                  <label class="default-client-setting-toggle">
+                    <span>Audio auto processing</span>
+                    <span class="admin-switch">
+                      <input type="checkbox" id="default-client-audio-processing" role="switch" />
+                      <span class="admin-switch__track" aria-hidden="true"></span>
+                      <span class="admin-switch__state" aria-hidden="true"></span>
+                    </span>
+                  </label>
+                  <label class="default-client-setting-toggle">
+                    <span>Left-hand mode</span>
+                    <span class="admin-switch">
+                      <input type="checkbox" id="default-client-left-hand" role="switch" />
+                      <span class="admin-switch__track" aria-hidden="true"></span>
+                      <span class="admin-switch__state" aria-hidden="true"></span>
+                    </span>
+                  </label>
+                  <label
+                    class="default-client-setting-toggle"
+                    title="Keep locked targets active while temporarily talking to or locking additional targets."
+                  >
+                    <span>Lock multiple targets</span>
+                    <span class="admin-switch">
+                      <input type="checkbox" id="default-client-lock-multiple" role="switch" />
+                      <span class="admin-switch__track" aria-hidden="true"></span>
+                      <span class="admin-switch__state" aria-hidden="true"></span>
+                    </span>
+                  </label>
+                  <div class="default-client-settings-actions">
+                    <button type="submit">Save defaults</button>
+                  </div>
+                </div>
+              </form>
+            </section>
+
+            <section class="config-panel config-backup-panel" aria-labelledby="config-backup-heading">
               <h3 id="config-backup-heading">Backup and restore</h3>
 
               <div class="setting-meta">

--- a/public/admin.js
+++ b/public/admin.js
@@ -104,6 +104,14 @@ const mediaNetworkQrDownloadButton = document.getElementById('media-network-qr-d
 const guestLoginEnabledInput = document.getElementById('guest-login-enabled');
 const guestLoginStatus = document.getElementById('guest-login-status');
 const guestLoginProfile = document.getElementById('guest-login-profile');
+const defaultClientSettingsForm = document.getElementById('default-client-settings-form');
+const defaultClientAudioProfile = document.getElementById('default-client-audio-profile');
+const defaultClientDimAmount = document.getElementById('default-client-dim-amount');
+const defaultClientDimSelf = document.getElementById('default-client-dim-self');
+const defaultClientDimIncoming = document.getElementById('default-client-dim-incoming');
+const defaultClientAudioProcessing = document.getElementById('default-client-audio-processing');
+const defaultClientLeftHand = document.getElementById('default-client-left-hand');
+const defaultClientLockMultiple = document.getElementById('default-client-lock-multiple');
 const adminImageLightbox = document.getElementById('admin-image-lightbox');
 const adminImageLightboxClose = document.getElementById('admin-image-lightbox-close');
 const adminImageLightboxImage = document.getElementById('admin-image-lightbox-image');
@@ -1848,6 +1856,7 @@ async function loadData() {
     return;
   }
   await loadGuestLoginSettings();
+  await loadDefaultClientSettings();
   const { users, conferences, feeds, bridges } = await fetchAdminCollections();
   await loadMdnsSettings();
   await loadMediaNetworkSettings();
@@ -2343,8 +2352,10 @@ async function renderUserList(users, conferences, feeds, bridges = currentBridge
       ? `
         <div class="nested-block">
           <form class="bridge-config-form" id="bridge-config-${user.id}" data-bridge-config-user-id="${user.id}" onsubmit="saveBridgeEndpoint(event, ${user.id})">
-            <label class="toggle-row" for="bridge-enabled-${user.id}">
-              <input type="checkbox" id="bridge-enabled-${user.id}" ${isBridgeEndpoint ? 'checked' : ''}>
+            <label class="admin-switch bridge-input-switch" for="bridge-enabled-${user.id}">
+              <input type="checkbox" id="bridge-enabled-${user.id}" role="switch" ${isBridgeEndpoint ? 'checked' : ''}>
+              <span class="admin-switch__track" aria-hidden="true"></span>
+              <span class="admin-switch__state" aria-hidden="true"></span>
               <span>Use this user as bridge endpoint</span>
             </label>
             <div class="bridge-config-options" id="bridge-options-${user.id}" ${isBridgeEndpoint ? '' : 'hidden'}>
@@ -2483,8 +2494,10 @@ async function renderFeedList(feeds) {
       <div class="nested" id="feed-nested-${feed.id}" onclick="event.stopPropagation()">
         <div class="nested-block">
           <form class="bridge-config-form" id="bridge-config-${formKey}" data-bridge-config-key="${formKey}" onsubmit="saveFeedBridgeEndpoint(event, ${feed.id})">
-            <label class="toggle-row" for="bridge-enabled-${formKey}">
-              <input type="checkbox" id="bridge-enabled-${formKey}" ${isBridgeEndpoint ? 'checked' : ''}>
+            <label class="admin-switch bridge-input-switch" for="bridge-enabled-${formKey}">
+              <input type="checkbox" id="bridge-enabled-${formKey}" role="switch" ${isBridgeEndpoint ? 'checked' : ''}>
+              <span class="admin-switch__track" aria-hidden="true"></span>
+              <span class="admin-switch__state" aria-hidden="true"></span>
               <span>Use this feed as bridge input</span>
             </label>
             <div class="bridge-config-options" id="bridge-options-${formKey}" ${isBridgeEndpoint ? '' : 'hidden'}>
@@ -2740,6 +2753,19 @@ async function loadGuestLoginSettings() {
     const profileName = payload?.profileName || 'Guest';
     guestLoginProfile.textContent = profileName;
   }
+  return payload;
+}
+
+async function loadDefaultClientSettings() {
+  const payload = await fetchJSON('/admin/settings/default-client');
+  const settings = payload?.settings || {};
+  if (defaultClientAudioProfile) defaultClientAudioProfile.value = settings.audioProfile || 'ultra-low';
+  if (defaultClientDimAmount) defaultClientDimAmount.value = String(settings.dimAmountDb ?? -14);
+  if (defaultClientDimSelf) defaultClientDimSelf.checked = settings.dimFeedsWhileSpeaking === true;
+  if (defaultClientDimIncoming) defaultClientDimIncoming.checked = settings.dimWhenAddressed === true;
+  if (defaultClientAudioProcessing) defaultClientAudioProcessing.checked = settings.audioAutoProcessing === true;
+  if (defaultClientLeftHand) defaultClientLeftHand.checked = settings.leftHandMode === true;
+  if (defaultClientLockMultiple) defaultClientLockMultiple.checked = settings.lockMultipleTargets === true;
   return payload;
 }
 
@@ -3716,6 +3742,40 @@ if (guestLoginEnabledInput) {
       showMessage(`❌ ${err.message || 'Failed to save Guest login'}`, 'error', 'config');
     } finally {
       guestLoginEnabledInput.disabled = false;
+    }
+  });
+}
+
+if (defaultClientSettingsForm) {
+  defaultClientSettingsForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const submitButton = defaultClientSettingsForm.querySelector('button[type="submit"]');
+    const settings = {
+      audioProfile: defaultClientAudioProfile?.value || 'ultra-low',
+      dimAmountDb: Number(defaultClientDimAmount?.value ?? -14),
+      dimFeedsWhileSpeaking: Boolean(defaultClientDimSelf?.checked),
+      dimWhenAddressed: Boolean(defaultClientDimIncoming?.checked),
+      audioAutoProcessing: Boolean(defaultClientAudioProcessing?.checked),
+      leftHandMode: Boolean(defaultClientLeftHand?.checked),
+      lockMultipleTargets: Boolean(defaultClientLockMultiple?.checked),
+    };
+
+    if (submitButton) submitButton.disabled = true;
+    try {
+      const res = await authedFetch('/admin/settings/default-client', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settings),
+      });
+      const payload = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(payload.error || 'Failed to save default client settings');
+      await loadDefaultClientSettings();
+      showMessage('✅ Default client settings saved', 'success', 'config');
+    } catch (error) {
+      console.error('Failed to save default client settings:', error);
+      showMessage(`❌ ${error.message || 'Failed to save default client settings'}`, 'error', 'config');
+    } finally {
+      if (submitButton) submitButton.disabled = false;
     }
   });
 }

--- a/public/client.js
+++ b/public/client.js
@@ -118,6 +118,7 @@ const FEED_DIM_INCOMING_STORAGE_KEY = 'feedDimIncoming';
 const AUDIO_PROCESSING_STORAGE_KEY = 'audioProcessingEnabled';
 const AUDIO_PROCESSING_EXPLICIT_STORAGE_KEY = 'audioProcessingEnabledExplicit';
 const LEFT_HAND_MODE_STORAGE_KEY = 'leftHandModeEnabled';
+const LOCK_MULTIPLE_TARGETS_STORAGE_KEY = 'lockMultipleTargetsEnabled';
 const FEED_INPUT_GAIN_DB_STORAGE_KEY = 'feedInputGainDb';
 const MIC_DEVICE_STORAGE_KEY = 'preferredAudioInputDeviceId';
 const OUTPUT_DEVICE_STORAGE_KEY = 'preferredAudioOutputDeviceId';
@@ -166,6 +167,18 @@ const DEFAULT_REPLY_HOTKEY_BINDING = Object.freeze({
   value: 'Space',
   label: 'Space',
 });
+
+const serverDefaultClientSettings = (
+  typeof window !== 'undefined'
+  && window.TALKTOME_DEFAULT_CLIENT_SETTINGS
+  && typeof window.TALKTOME_DEFAULT_CLIENT_SETTINGS === 'object'
+)
+  ? window.TALKTOME_DEFAULT_CLIENT_SETTINGS
+  : {};
+
+function hasServerDefaultClientSetting(key) {
+  return Object.prototype.hasOwnProperty.call(serverDefaultClientSettings, key);
+}
 
 const TARGET_HOTKEY_DIGITS = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
 const DEFAULT_TARGET_HOTKEY_BINDINGS = Object.freeze(
@@ -233,14 +246,25 @@ let recoverExistingIncomingPlayback = () => {};
 let attemptPlayAudio = () => Promise.resolve();
 let loadedTargetHotkeyStorageKey = null;
 
-let feedDuckingDb = DEFAULT_FEED_DUCKING_DB;
+let feedDuckingDb = hasServerDefaultClientSetting('dimAmountDb')
+  ? clampFeedDuckingDb(Number(serverDefaultClientSettings.dimAmountDb))
+  : DEFAULT_FEED_DUCKING_DB;
 let feedDuckingFactor = dbToLinear(feedDuckingDb);
-let feedDimSelf = false;
-let feedDimIncoming = true;
+let feedDimSelf = hasServerDefaultClientSetting('dimFeedsWhileSpeaking')
+  ? serverDefaultClientSettings.dimFeedsWhileSpeaking === true
+  : false;
+let feedDimIncoming = hasServerDefaultClientSetting('dimWhenAddressed')
+  ? serverDefaultClientSettings.dimWhenAddressed === true
+  : true;
 let audioProcessingEnabled = false;
 let audioProcessingReinitializePending = false;
 let refreshTalkProducerForAudioProcessingChange = null;
-let leftHandModeEnabled = false;
+let leftHandModeEnabled = hasServerDefaultClientSetting('leftHandMode')
+  ? serverDefaultClientSettings.leftHandMode === true
+  : false;
+let lockMultipleTargetsEnabled = hasServerDefaultClientSetting('lockMultipleTargets')
+  ? serverDefaultClientSettings.lockMultipleTargets === true
+  : false;
 let feedInputProcessingEnabled = false;
 let feedPtimeMs = DEFAULT_FEED_PTIME_MS;
 const audioProcessingOptions = {
@@ -550,6 +574,8 @@ if (typeof window !== 'undefined') {
     const storedProcessing = window.localStorage?.getItem(AUDIO_PROCESSING_STORAGE_KEY);
     if (storedProcessingExplicit !== null && storedProcessing !== null) {
       audioProcessingEnabled = storedProcessing === 'true';
+    } else if (hasServerDefaultClientSetting('audioAutoProcessing')) {
+      audioProcessingEnabled = serverDefaultClientSettings.audioAutoProcessing === true;
     } else {
       // Default: enable processing on mobile/tablet browsers, disable on desktop.
       // Legacy stored values without an explicit marker should not keep mobile
@@ -563,6 +589,10 @@ if (typeof window !== 'undefined') {
     const storedLeftHandMode = window.localStorage?.getItem(LEFT_HAND_MODE_STORAGE_KEY);
     if (storedLeftHandMode !== null) {
       leftHandModeEnabled = storedLeftHandMode === 'true';
+    }
+    const storedLockMultipleTargets = window.localStorage?.getItem(LOCK_MULTIPLE_TARGETS_STORAGE_KEY);
+    if (storedLockMultipleTargets !== null) {
+      lockMultipleTargetsEnabled = storedLockMultipleTargets === 'true';
     }
     const storedInputGainDb = window.localStorage?.getItem(FEED_INPUT_GAIN_DB_STORAGE_KEY);
     if (storedInputGainDb !== null) {
@@ -884,6 +914,7 @@ let dimWhileSpeakingToggle;
 let dimWhenAddressedToggle;
 let audioProcessingToggle;
 let leftHandModeToggle;
+let lockMultipleTargetsToggle;
 let userLevelControls;
 let userInputGainSlider;
 let userInputGainValueDisplay;
@@ -3052,7 +3083,8 @@ function currentQualityKey() {
   const stored = localStorage.getItem('audioQualityProfile');
   if (stored && QUALITY_PROFILES[stored]) return stored;
 
-  return 'ultra-low';
+  const serverDefault = serverDefaultClientSettings.audioProfile;
+  return QUALITY_PROFILES[serverDefault] ? serverDefault : 'ultra-low';
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -3078,6 +3110,7 @@ document.addEventListener("DOMContentLoaded", () => {
   dimWhenAddressedToggle = document.getElementById('toggle-incoming-dim');
   audioProcessingToggle = document.getElementById('toggle-processing');
   leftHandModeToggle = document.getElementById('toggle-left-hand-mode');
+  lockMultipleTargetsToggle = document.getElementById('toggle-lock-multiple-targets');
   userLevelControls = document.getElementById('user-level-controls');
   userInputGainSlider = document.getElementById('user-input-gain');
   userInputGainValueDisplay = document.getElementById('user-input-gain-value');
@@ -3236,13 +3269,50 @@ document.addEventListener("DOMContentLoaded", () => {
     setLeftHandMode(leftHandModeToggle.checked);
   });
 
+  function setLockMultipleTargets(value, { persist = true } = {}) {
+    const wasEnabled = lockMultipleTargetsEnabled;
+    lockMultipleTargetsEnabled = Boolean(value);
+    if (lockMultipleTargetsToggle && lockMultipleTargetsToggle.checked !== lockMultipleTargetsEnabled) {
+      lockMultipleTargetsToggle.checked = lockMultipleTargetsEnabled;
+    }
+    if (persist && typeof window !== 'undefined') {
+      try {
+        window.localStorage?.setItem(LOCK_MULTIPLE_TARGETS_STORAGE_KEY, String(lockMultipleTargetsEnabled));
+      } catch (error) {
+        console.warn('Unable to persist multiple-target lock mode:', error);
+      }
+    }
+    if (wasEnabled && !lockMultipleTargetsEnabled && activeTalkLocks.size > 1) {
+      const [lockToKeep, ...locksToRemove] = getActiveTalkLockEntries();
+      locksToRemove.forEach((entry) => {
+        setTalkButtonLocked(entry.button, false);
+        activeTalkLocks.delete(getTalkTargetIdentity(entry.target));
+      });
+      setCurrentTalkTargets(collectActiveTalkTargetsFromPointers());
+      emitTalkTargetsUpdated('talk-targets-updated', currentTargets);
+      emitPttState('multiple-target-lock-disabled', {
+        talking: currentTargets.length > 0,
+        lockActive: Boolean(lockToKeep),
+        target: lockToKeep?.target || currentTargets[0] || null,
+        targets: currentTargets,
+      });
+    }
+  }
+
+  setLockMultipleTargets(lockMultipleTargetsEnabled, { persist: false });
+  lockMultipleTargetsToggle?.addEventListener('change', () => {
+    setLockMultipleTargets(lockMultipleTargetsToggle.checked);
+  });
+
   const storedQuality = localStorage.getItem('audioQualityProfile');
+  const defaultQuality = QUALITY_PROFILES[serverDefaultClientSettings.audioProfile]
+    ? serverDefaultClientSettings.audioProfile
+    : 'ultra-low';
   if (qualitySelect) {
     if (storedQuality && QUALITY_PROFILES[storedQuality]) {
       qualitySelect.value = storedQuality;
     } else {
-      qualitySelect.value = 'ultra-low';
-      localStorage.setItem('audioQualityProfile', 'ultra-low');
+      qualitySelect.value = defaultQuality;
     }
 
     qualitySelect.addEventListener('change', () => {
@@ -3256,8 +3326,6 @@ document.addEventListener("DOMContentLoaded", () => {
         startVoiceTriggerMonitoring();
       }
     });
-  } else if (!storedQuality || !QUALITY_PROFILES[storedQuality]) {
-    localStorage.setItem('audioQualityProfile', 'ultra-low');
   }
 
   function setFeedDuckingDb(dbValue, { persist = true, apply = true } = {}) {
@@ -3836,8 +3904,7 @@ let cachedOperatorTargets = null;
   let initializingMediaPromise = null;
   let mediaStateGeneration = 0;
   let shouldInitializeAfterConnect = false;
-  let activeLockButton = null;
-  let activeLockTarget = null;
+  const activeTalkLocks = new Map();
   let suspendedLockState = null;
   let suspendedLockRestoreTimer = null;
   let pendingPttSizingRaf = null;
@@ -4361,16 +4428,42 @@ let cachedOperatorTargets = null;
     return normalizedTargets;
   }
 
+  function getActiveTalkLockEntries() {
+    return Array.from(activeTalkLocks.values());
+  }
+
+  function getActiveTalkLockTargets() {
+    return getActiveTalkLockEntries().map((entry) => entry.target);
+  }
+
+  function hasActiveTalkLocks() {
+    return activeTalkLocks.size > 0;
+  }
+
+  function getTalkLockEntry(target) {
+    const identity = getTalkTargetIdentity(target);
+    return identity ? activeTalkLocks.get(identity) || null : null;
+  }
+
+  function isTalkTargetLocked(target) {
+    return Boolean(getTalkLockEntry(target));
+  }
+
+  function isTalkButtonLocked(button) {
+    return Boolean(button && getActiveTalkLockEntries().some((entry) => entry.button === button));
+  }
+
   function getCurrentPttState(overrides = {}) {
+    const firstLockedTarget = getActiveTalkLockTargets()[0] || null;
     const baseTarget = overrides.target !== undefined
       ? overrides.target
-      : ((currentTargets[0] || currentTarget || activeLockTarget || null));
+      : ((currentTargets[0] || currentTarget || firstLockedTarget || null));
     const baseTargets = overrides.targets !== undefined
       ? overrides.targets
       : (currentTargets.length > 0 ? currentTargets : (baseTarget ? [baseTarget] : []));
     return {
       talking: typeof overrides.talking === 'boolean' ? overrides.talking : Boolean(isTalking || pendingTalkStart),
-      lockActive: typeof overrides.lockActive === 'boolean' ? overrides.lockActive : Boolean(activeLockButton),
+      lockActive: typeof overrides.lockActive === 'boolean' ? overrides.lockActive : hasActiveTalkLocks(),
       target: normalizePttTarget(baseTarget),
       targets: normalizePttTargets(baseTargets),
     };
@@ -4459,7 +4552,7 @@ let cachedOperatorTargets = null;
       clearHotkeyActiveStyles();
       pressedHotkeyBindings.clear();
       setSelfTalkingKey(null);
-      if (activeLockButton || activeLockTarget) {
+      if (hasActiveTalkLocks()) {
         clearLockState();
       }
     });
@@ -7718,7 +7811,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
             && (!producer || producer.closed || producer.paused)
             && !pendingTalkStart
             && !isTalking
-            && !activeLockButton
+            && !hasActiveTalkLocks()
           ) {
             voiceTriggerActive = true;
             voiceTriggerBelowSince = 0;
@@ -8257,21 +8350,27 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
         const normalizedTarget = { type: 'user', id: currentSocketId };
 
-        if (activeLockButton) {
-          if (activeLockButton === talkBtn) {
+        if (hasActiveTalkLocks()) {
+          if (isTalkTargetLocked(normalizedTarget)) {
             li.classList.remove('ptt-pressing');
-            handleStopTalking({ preventDefault() {}, currentTarget: talkBtn });
+            if (lockMultipleTargetsEnabled) {
+              removeTalkLock(normalizedTarget);
+            } else {
+              handleStopTalking({ preventDefault() {}, currentTarget: talkBtn });
+            }
             return;
           }
-          suspendActiveLockState();
-          handleStopTalking({ preventDefault() {}, currentTarget: null, suppressLockRestore: true });
+          if (!lockMultipleTargetsEnabled) {
+            suspendActiveLockState();
+            handleStopTalking({ preventDefault() {}, currentTarget: null, suppressLockRestore: true });
+          }
         }
 
         const startX = e.clientX;
         let lockedByGesture = false;
 
         const onMove = (ev) => {
-          if (lockedByGesture || activeLockButton === talkBtn) return;
+          if (lockedByGesture || isTalkButtonLocked(talkBtn)) return;
           if (didReachSlideToLockThreshold(ev.clientX, startX)) {
             lockedByGesture = true;
             activateTalkLock(normalizedTarget, talkBtn);
@@ -8288,7 +8387,6 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
         const onEnd = (ev) => {
           cleanup();
           li.classList.remove('ptt-pressing');
-          if (activeLockButton === talkBtn) return;
           handleStopTalking(ev);
         };
 
@@ -8325,9 +8423,9 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
       applyMuteVisualState(li, initialMuted);
 
       if (isOnline) {
-        const isLocked = isSameTarget(activeLockTarget, { type: 'user', id: socketId });
-        if (isLocked) {
-          activeLockButton = talkBtn;
+        const lockEntry = getTalkLockEntry({ type: 'user', id: socketId });
+        if (lockEntry) {
+          lockEntry.button = talkBtn;
           setTalkButtonLocked(talkBtn, true);
         }
       }
@@ -8343,7 +8441,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
       let rowPttLockedByGesture = false;
       li.addEventListener('pointermove', (e) => {
         if (!rowPttGestureActive) return;
-        if (rowPttLockedByGesture || activeLockButton === talkBtn) return;
+        if (rowPttLockedByGesture || isTalkButtonLocked(talkBtn)) return;
         if (didReachSlideToLockThreshold(e.clientX, rowPttStartX)) {
           const currentSocketId = resolveCurrentUserSocketId();
           if (!currentSocketId) return;
@@ -8363,11 +8461,16 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
             const currentSocketId = resolveCurrentUserSocketId();
             if (!currentSocketId) return;
             const targetData = { type: 'user', id: currentSocketId };
-            if (activeLockButton && isSameTarget(activeLockTarget, targetData)) {
-              handleStopTalking({ preventDefault() {}, currentTarget: activeLockButton });
+            const existingLock = getTalkLockEntry(targetData);
+            if (existingLock) {
+              if (lockMultipleTargetsEnabled) {
+                removeTalkLock(targetData);
+              } else {
+                handleStopTalking({ preventDefault() {}, currentTarget: existingLock.button });
+              }
               return;
             }
-            if (activeLockButton && !isSameTarget(activeLockTarget, targetData)) {
+            if (hasActiveTalkLocks() && !lockMultipleTargetsEnabled) {
               suspendActiveLockState();
               handleStopTalking({ preventDefault() {}, currentTarget: null, suppressLockRestore: true });
               rowPttGestureActive = true;
@@ -8393,7 +8496,6 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
             rowPttGestureActive = false;
             li.classList.remove('ptt-pressing');
             try { li.releasePointerCapture(e.pointerId); } catch {}
-            if (activeLockButton === talkBtn) return;
           }
           handleStopTalking(e);
         });
@@ -8895,21 +8997,27 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
         const normalizedTarget = { type: 'conference', id };
 
-        if (activeLockButton) {
-          if (activeLockButton === talkBtn) {
+        if (hasActiveTalkLocks()) {
+          if (isTalkTargetLocked(normalizedTarget)) {
             li.classList.remove('ptt-pressing');
-            handleStopTalking({ preventDefault() {}, currentTarget: talkBtn });
+            if (lockMultipleTargetsEnabled) {
+              removeTalkLock(normalizedTarget);
+            } else {
+              handleStopTalking({ preventDefault() {}, currentTarget: talkBtn });
+            }
             return;
           }
-          suspendActiveLockState();
-          handleStopTalking({ preventDefault() {}, currentTarget: null, suppressLockRestore: true });
+          if (!lockMultipleTargetsEnabled) {
+            suspendActiveLockState();
+            handleStopTalking({ preventDefault() {}, currentTarget: null, suppressLockRestore: true });
+          }
         }
 
         const startX = e.clientX;
         let lockedByGesture = false;
 
         const onMove = (ev) => {
-          if (lockedByGesture || activeLockButton === talkBtn) return;
+          if (lockedByGesture || isTalkButtonLocked(talkBtn)) return;
           if (didReachSlideToLockThreshold(ev.clientX, startX)) {
             lockedByGesture = true;
             activateTalkLock(normalizedTarget, talkBtn);
@@ -8926,7 +9034,6 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
         const onEnd = (ev) => {
           cleanup();
           li.classList.remove('ptt-pressing');
-          if (activeLockButton === talkBtn) return;
           handleStopTalking(ev);
         };
 
@@ -8939,8 +9046,9 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
       actions.append(muteBtn, talkBtn);
 
-      if (isSameTarget(activeLockTarget, { type: 'conference', id })) {
-        activeLockButton = talkBtn;
+      const lockEntry = getTalkLockEntry({ type: 'conference', id });
+      if (lockEntry) {
+        lockEntry.button = talkBtn;
         setTalkButtonLocked(talkBtn, true);
       }
 
@@ -8950,7 +9058,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
       let rowPttLockedByGesture = false;
       li.addEventListener('pointermove', (e) => {
         if (!rowPttGestureActive) return;
-        if (rowPttLockedByGesture || activeLockButton === talkBtn) return;
+        if (rowPttLockedByGesture || isTalkButtonLocked(talkBtn)) return;
         if (didReachSlideToLockThreshold(e.clientX, rowPttStartX)) {
           rowPttLockedByGesture = true;
           activateTalkLock({ type: 'conference', id }, talkBtn);
@@ -8967,11 +9075,16 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
           ) return;
           if (ev === 'down') {
             const targetData = { type: 'conference', id };
-            if (activeLockButton && isSameTarget(activeLockTarget, targetData)) {
-              handleStopTalking({ preventDefault() {}, currentTarget: activeLockButton });
+            const existingLock = getTalkLockEntry(targetData);
+            if (existingLock) {
+              if (lockMultipleTargetsEnabled) {
+                removeTalkLock(targetData);
+              } else {
+                handleStopTalking({ preventDefault() {}, currentTarget: existingLock.button });
+              }
               return;
             }
-            if (activeLockButton && !isSameTarget(activeLockTarget, targetData)) {
+            if (hasActiveTalkLocks() && !lockMultipleTargetsEnabled) {
               suspendActiveLockState();
               handleStopTalking({ preventDefault() {}, currentTarget: null, suppressLockRestore: true });
               rowPttGestureActive = true;
@@ -8997,7 +9110,6 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
             rowPttGestureActive = false;
             li.classList.remove('ptt-pressing');
             try { li.releasePointerCapture(e.pointerId); } catch {}
-            if (activeLockButton === talkBtn) return;
           }
           handleStopTalking(e);
         });
@@ -9119,7 +9231,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
     // Re-apply outgoing talk highlight after re-rendering the target list.
     // The list is rebuilt via `innerHTML = ''`, so any previous DOM classes
     // (like "talking-to") are lost even though the producer may still be live.
-    if (producer || isTalking || activeLockTarget) {
+    if (producer || isTalking || hasActiveTalkLocks()) {
       const activeTargetsToHighlight = currentTargets.length > 0
         ? currentTargets
         : (currentTarget ? [currentTarget] : []);
@@ -9131,11 +9243,13 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
         document.querySelector(selector)?.classList.add('talking-to');
       });
 
-      if (activeTargetsToHighlight.length === 0 && activeLockTarget) {
-        const selector = activeLockTarget.type === 'conference'
-          ? `#conf-${activeLockTarget.id}`
-          : `#user-${activeLockTarget.id}`;
-        document.querySelector(selector)?.classList.add('talking-to');
+      if (activeTargetsToHighlight.length === 0) {
+        getActiveTalkLockTargets().forEach((lockedTarget) => {
+          const selector = lockedTarget.type === 'conference'
+            ? `#conf-${lockedTarget.id}`
+            : `#user-${lockedTarget.id}`;
+          document.querySelector(selector)?.classList.add('talking-to');
+        });
       }
     }
 
@@ -9178,8 +9292,19 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
       applyFeedDucking();
     }
 
-    if (activeLockButton && !document.body.contains(activeLockButton)) {
-      handleStopTalking({ preventDefault() {}, currentTarget: activeLockButton });
+    let removedUnavailableLock = false;
+    getActiveTalkLockEntries().forEach((entry) => {
+      if (entry.button && document.body.contains(entry.button) && !entry.button.disabled) return;
+      activeTalkLocks.delete(getTalkTargetIdentity(entry.target));
+      removedUnavailableLock = true;
+    });
+    if (removedUnavailableLock) {
+      setCurrentTalkTargets(collectActiveTalkTargetsFromPointers());
+      if (currentTargets.length > 0) {
+        emitTalkTargetsUpdated('talk-targets-updated', currentTargets);
+      } else {
+        handleStopTalking({ preventDefault() {}, currentTarget: null, suppressLockRestore: true });
+      }
     }
 
     pruneIncomingStreamBookkeeping();
@@ -10212,12 +10337,12 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
     const isFeed = targetKey.startsWith("feed-");
 
     let lockTargetMatches = false;
-    if (activeLockButton && !isFeed && (isConference || isUser)) {
+    if (hasActiveTalkLocks() && !isFeed && (isConference || isUser)) {
       const candidate = {
         type: isConference ? "conference" : "user",
         id: rawId,
       };
-      lockTargetMatches = isSameTarget(activeLockTarget, candidate);
+      lockTargetMatches = isTalkTargetLocked(candidate);
     }
 
     if (isSpeaking) {
@@ -10329,6 +10454,13 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
   function collectActiveTalkTargetsFromPointers() {
     const collectedTargets = [];
     const seen = new Set();
+    for (const lockedTarget of getActiveTalkLockTargets()) {
+      const normalizedTarget = normalizePttTarget(lockedTarget);
+      const identity = getTalkTargetIdentity(normalizedTarget);
+      if (!normalizedTarget || !identity || seen.has(identity)) continue;
+      seen.add(identity);
+      collectedTargets.push(normalizedTarget);
+    }
     for (const pointerState of activeTalkPointers.values()) {
       const normalizedTarget = normalizePttTarget(pointerState?.target);
       if (!normalizedTarget) continue;
@@ -10437,7 +10569,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
   function canUseTargetHotkeys(event) {
     if (!isOperatorSession()) return false;
-    if (activeLockButton) return false;
+    if (hasActiveTalkLocks() && !lockMultipleTargetsEnabled) return false;
     if (settingsMenuOpen) return false;
     if (conferenceMembersModal && !conferenceMembersModal.hidden) return false;
     if (activeHotkeyCaptureTargetIdentity) return false;
@@ -10556,10 +10688,9 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
   }
 
   function clearLockState() {
-    if (!activeLockButton) return;
-    setTalkButtonLocked(activeLockButton, false);
-    activeLockButton = null;
-    activeLockTarget = null;
+    if (!hasActiveTalkLocks()) return;
+    getActiveTalkLockEntries().forEach((entry) => setTalkButtonLocked(entry.button, false));
+    activeTalkLocks.clear();
     setSelfTalkingKey(null);
     emitPttState('lock-cleared', { lockActive: false });
   }
@@ -10592,11 +10723,25 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
   function activateTalkLock(target, button) {
     if (!isOperatorSession()) return;
     if (!target || !button) return;
+    const normalizedTarget = normalizePttTarget(target);
+    const identity = getTalkTargetIdentity(normalizedTarget);
+    if (!normalizedTarget || !identity) return;
     clearSuspendedLockState();
-    activeLockButton = button;
-    activeLockTarget = { type: target.type, id: target.id };
+    if (!lockMultipleTargetsEnabled) {
+      getActiveTalkLockEntries().forEach((entry) => {
+        if (getTalkTargetIdentity(entry.target) !== identity) {
+          setTalkButtonLocked(entry.button, false);
+          activeTalkLocks.delete(getTalkTargetIdentity(entry.target));
+        }
+      });
+    }
+    activeTalkLocks.set(identity, { target: normalizedTarget, button });
     setTalkButtonLocked(button, true);
-    emitPttState('lock-activated', { lockActive: true, target });
+    emitPttState('lock-activated', {
+      lockActive: true,
+      target: normalizedTarget,
+      targets: getActiveTalkLockTargets(),
+    });
   }
 
   function findTalkButtonForTarget(target) {
@@ -10612,10 +10757,12 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
   function suspendActiveLockState() {
     if (!isOperatorSession()) return null;
-    if (!activeLockButton || !activeLockTarget) return null;
+    if (!hasActiveTalkLocks()) return null;
     suspendedLockState = {
-      target: { type: activeLockTarget.type, id: activeLockTarget.id },
-      button: activeLockButton,
+      locks: getActiveTalkLockEntries().map((entry) => ({
+        target: { type: entry.target.type, id: entry.target.id },
+        button: entry.button,
+      })),
     };
     clearLockState();
     return suspendedLockState;
@@ -10637,18 +10784,46 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
       const lockState = suspendedLockState;
       suspendedLockState = null;
-      const target = lockState?.target || null;
-      const button = lockState?.button && document.body.contains(lockState.button)
-        ? lockState.button
-        : findTalkButtonForTarget(target);
+      const restoredLocks = (lockState?.locks || [])
+        .map((lock) => {
+          const target = lock?.target || null;
+          const button = lock?.button && document.body.contains(lock.button)
+            ? lock.button
+            : findTalkButtonForTarget(target);
+          return target && button && !button.disabled ? { target, button } : null;
+        })
+        .filter(Boolean);
 
-      if (!target || !button || button.disabled) {
-        return;
+      restoredLocks.forEach(({ target, button }) => activateTalkLock(target, button));
+      const firstTarget = restoredLocks[0]?.target || null;
+      if (firstTarget) {
+        handleTalk({ preventDefault() {} }, firstTarget);
       }
-
-      activateTalkLock(target, button);
-      handleTalk({ preventDefault() {} }, { type: target.type, id: target.id });
     }, 0);
+  }
+
+  function removeTalkLock(target) {
+    const identity = getTalkTargetIdentity(target);
+    const entry = identity ? activeTalkLocks.get(identity) : null;
+    if (!entry) return false;
+    setTalkButtonLocked(entry.button, false);
+    activeTalkLocks.delete(identity);
+    setCurrentTalkTargets(collectActiveTalkTargetsFromPointers());
+
+    if (currentTargets.length > 0) {
+      emitTalkTargetsUpdated('talk-targets-updated', currentTargets);
+      emitPttState('lock-removed', {
+        talking: true,
+        lockActive: hasActiveTalkLocks(),
+        target: currentTargets[0] || null,
+        targets: currentTargets,
+      });
+      applyFeedDucking();
+      return true;
+    }
+
+    handleStopTalking({ preventDefault() {}, currentTarget: null, suppressLockRestore: true });
+    return true;
   }
 
   function toggleTalkLock(target) {
@@ -10657,15 +10832,22 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
     const talkBtn = findTalkButtonForTarget(target);
     if (!talkBtn) return;
 
-    if (isSameTarget(activeLockTarget, target) && activeLockButton) {
-      handleStopTalking({ preventDefault() {}, currentTarget: activeLockButton });
+    const existingLock = getTalkLockEntry(target);
+    if (existingLock) {
+      if (lockMultipleTargetsEnabled) {
+        removeTalkLock(target);
+      } else {
+        handleStopTalking({ preventDefault() {}, currentTarget: existingLock.button });
+      }
       return;
     }
 
-    if (activeLockButton && activeLockButton !== talkBtn) {
-      handleStopTalking({ preventDefault() {}, currentTarget: activeLockButton });
+    if (hasActiveTalkLocks() && !lockMultipleTargetsEnabled) {
+      handleStopTalking({ preventDefault() {}, currentTarget: getActiveTalkLockEntries()[0]?.button || null });
     } else if (producer) {
-      handleStopTalking({ preventDefault() {}, currentTarget: talkBtn });
+      if (!lockMultipleTargetsEnabled) {
+        handleStopTalking({ preventDefault() {}, currentTarget: talkBtn });
+      }
     }
 
     activateTalkLock(target, talkBtn);
@@ -10701,7 +10883,10 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
     if (inputKey !== null) {
       addPressedTalkPointer(inputKey, normalizedTarget);
     } else {
-      setCurrentTalkTargets([normalizedTarget]);
+      setCurrentTalkTargets(normalizePttTargets([
+        ...getActiveTalkLockTargets(),
+        normalizedTarget,
+      ]));
     }
 
     const effectiveTargets = currentTargets.length > 0 ? currentTargets : [normalizedTarget];
@@ -10728,7 +10913,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
         await resumeTalkProducer(producer);
         emitPttState('talk-started', {
           talking: true,
-          lockActive: Boolean(activeLockButton),
+          lockActive: hasActiveTalkLocks(),
           target: effectiveTargets[0] || null,
           targets: effectiveTargets,
         });
@@ -10739,7 +10924,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
         emitTalkTargetsUpdated('talk-targets-cleared', []);
         emitPttState('talk-start-failed', {
           talking: false,
-          lockActive: Boolean(activeLockButton),
+          lockActive: hasActiveTalkLocks(),
           target: null,
           targets: [],
         });
@@ -10752,7 +10937,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
       emitTalkTargetsUpdated('talk-targets-updated', effectiveTargets);
       emitPttState('talk-targets-updated', {
         talking: true,
-        lockActive: Boolean(activeLockButton),
+        lockActive: hasActiveTalkLocks(),
         target: effectiveTargets[0] || null,
         targets: effectiveTargets,
       });
@@ -10897,8 +11082,8 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
       emitTalkTargetsUpdated('talk-targets-cleared', []);
       emitPttState('talk-start-failed', {
         talking: false,
-        lockActive: Boolean(activeLockButton),
-        target: activeLockTarget || null,
+        lockActive: hasActiveTalkLocks(),
+        target: getActiveTalkLockTargets()[0] || null,
         targets: [],
       });
     }
@@ -10937,7 +11122,12 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
     const inputKey = getTalkInputKey(e);
     let producerPausePromise = null;
 
-    if (activeLockButton && e.currentTarget && e.currentTarget !== activeLockButton) {
+    if (
+      !lockMultipleTargetsEnabled
+      && hasActiveTalkLocks()
+      && e.currentTarget
+      && !isTalkButtonLocked(e.currentTarget)
+    ) {
       return;
     }
 
@@ -10947,7 +11137,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
         emitTalkTargetsUpdated('talk-targets-updated', currentTargets);
         emitPttState('talk-targets-updated', {
           talking: true,
-          lockActive: Boolean(activeLockButton),
+          lockActive: hasActiveTalkLocks(),
           target: currentTargets[0] || null,
           targets: currentTargets,
         });
@@ -11018,7 +11208,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
   function stopTalkingSafely({ respectLock = false, pointerId = null } = {}) {
     if (!isOperatorSession()) return;
     if (!producer && !isTalking && !pendingTalkStart) return;
-    if (respectLock && activeLockButton) return;
+    if (respectLock && hasActiveTalkLocks()) return;
     if (pointerId !== null) {
       if (activeTalkPointers.has(pointerId)) {
         handleStopTalking({ preventDefault() {}, currentTarget: null, pointerId });

--- a/public/index.html
+++ b/public/index.html
@@ -403,7 +403,7 @@
 
       .settings-subheader {
         display: grid;
-        grid-template-columns: auto minmax(0, 1fr);
+        grid-template-columns: auto minmax(0, 1fr) auto;
         align-items: center;
         gap: 0.75rem;
         padding-bottom: 0.2rem;
@@ -447,13 +447,6 @@
 
       .shortcut-settings[hidden] {
         display: none !important;
-      }
-
-      .shortcut-settings__header {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-        gap: 0.75rem;
       }
 
       .shortcut-settings__title {
@@ -1812,6 +1805,76 @@
         margin-left: 1.8rem;
       }
 
+      .processing-options label.settings-switch,
+      .voice-trigger-controls label.settings-switch {
+        position: relative;
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
+        align-items: center;
+        justify-content: initial;
+        gap: 0.25rem 0.65rem;
+        width: 100%;
+        cursor: pointer;
+        user-select: none;
+      }
+
+      .settings-switch input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      .settings-switch__track {
+        position: relative;
+        width: 2.8rem;
+        height: 1.5rem;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        border-radius: 999px;
+        background: rgba(148, 163, 184, 0.18);
+        transition: border-color 0.15s ease, background 0.15s ease;
+      }
+
+      .settings-switch__track::after {
+        content: '';
+        position: absolute;
+        top: 0.17rem;
+        left: 0.17rem;
+        width: 1.05rem;
+        height: 1.05rem;
+        border-radius: 50%;
+        background: #cbd5e1;
+        box-shadow: 0 1px 3px rgba(15, 23, 42, 0.5);
+        transition: transform 0.15s ease, background 0.15s ease;
+      }
+
+      .settings-switch input:checked + .settings-switch__track {
+        border-color: rgba(59, 130, 246, 0.75);
+        background: rgba(37, 99, 235, 0.75);
+      }
+
+      .settings-switch input:checked + .settings-switch__track::after {
+        background: #fff;
+        transform: translateX(1.3rem);
+      }
+
+      .settings-switch input:focus,
+      .settings-switch input:focus-visible {
+        outline: none;
+      }
+
+      .settings-switch input:focus-visible + .settings-switch__track {
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+      }
+
+      .processing-options label.settings-switch .processing-desc {
+        grid-column: 2;
+        margin-left: 0;
+      }
+
       @media (min-width: 980px) {
         .processing-options label.processing-setting-label {
           flex-direction: row;
@@ -1822,6 +1885,10 @@
         .processing-options label.processing-setting-label .processing-desc {
           display: inline;
           margin-left: 0;
+        }
+
+        .processing-options label.settings-switch.processing-setting-label {
+          display: flex;
         }
       }
 
@@ -2154,36 +2221,42 @@
                 </select>
               </div>
               <div class="processing-options feed-optional feed-dim-option">
-                <label>
-                  <span class="processing-inline">
-                    <input type="checkbox" id="toggle-self-dim" />
-                    Dim feeds while speaking
-                  </span>
+                <label class="settings-switch">
+                  <input type="checkbox" id="toggle-self-dim" role="switch" />
+                  <span class="settings-switch__track" aria-hidden="true"></span>
+                  <span>Dim feeds while speaking</span>
                 </label>
               </div>
               <div class="processing-options feed-optional feed-dim-option">
-                <label>
-                  <span class="processing-inline">
-                    <input type="checkbox" id="toggle-incoming-dim" />
-                    Dim when addressed
-                  </span>
+                <label class="settings-switch">
+                  <input type="checkbox" id="toggle-incoming-dim" role="switch" />
+                  <span class="settings-switch__track" aria-hidden="true"></span>
+                  <span>Dim when addressed</span>
                 </label>
               </div>
               <div class="processing-options feed-optional">
-                <label class="processing-setting-label">
-                  <span class="processing-inline">
-                    <input type="checkbox" id="toggle-processing" />
-                    Audio auto processing
-                  </span>
+                <label class="processing-setting-label settings-switch">
+                  <input type="checkbox" id="toggle-processing" role="switch" />
+                  <span class="settings-switch__track" aria-hidden="true"></span>
+                  <span>Audio auto processing</span>
                   <span class="processing-desc">(auto gain, noise cancellation, echo suppression - adds ~50 ms latency)</span>
                 </label>
               </div>
               <div class="processing-options feed-optional">
-                <label>
-                  <span class="processing-inline">
-                    <input type="checkbox" id="toggle-left-hand-mode" />
-                    Left-hand mode
-                  </span>
+                <label class="settings-switch">
+                  <input type="checkbox" id="toggle-left-hand-mode" role="switch" />
+                  <span class="settings-switch__track" aria-hidden="true"></span>
+                  <span>Left-hand mode</span>
+                </label>
+              </div>
+              <div class="processing-options feed-optional">
+                <label
+                  class="settings-switch"
+                  title="Keep locked targets active while temporarily talking to or locking additional targets."
+                >
+                  <input type="checkbox" id="toggle-lock-multiple-targets" role="switch" />
+                  <span class="settings-switch__track" aria-hidden="true"></span>
+                  <span>Lock multiple targets</span>
                 </label>
               </div>
               <div class="user-level-controls feed-optional" id="user-level-controls">
@@ -2217,11 +2290,10 @@
                 </div>
               </div>
               <div class="voice-trigger-controls feed-optional" id="voice-trigger-controls">
-                <label>
-                  <span class="processing-inline">
-                    <input type="checkbox" id="toggle-voice-trigger" />
-                    Level trigger
-                  </span>
+                <label class="settings-switch">
+                  <input type="checkbox" id="toggle-voice-trigger" role="switch" />
+                  <span class="settings-switch__track" aria-hidden="true"></span>
+                  <span>Level trigger</span>
                 </label>
                 <label for="voice-trigger-target">Target</label>
                 <select id="voice-trigger-target">
@@ -2258,13 +2330,11 @@
               <div class="settings-subheader">
                 <button type="button" class="settings-back-button" id="shortcut-settings-back">Back</button>
                 <span class="settings-subheader__title">Keyboard shortcuts</span>
+                <button type="button" class="shortcut-settings__button shortcut-settings__button--secondary" id="shortcut-reset-btn">
+                  Reset all
+                </button>
               </div>
               <div class="shortcut-settings feed-optional" id="shortcut-settings" hidden>
-                <div class="shortcut-settings__header">
-                  <button type="button" class="shortcut-settings__button shortcut-settings__button--secondary" id="shortcut-reset-btn">
-                    Reset all
-                  </button>
-                </div>
                 <p class="shortcut-settings__desc">
                   Targets default to 1-9 in target order. Reply defaults to Space. Click Set key and press a key to store a custom shortcut.
                 </p>
@@ -2468,6 +2538,7 @@
   <script src="/mediasoup-client.js"></script>
   <script src="/receivePlaybackPolicy.js"></script>
   <script src="/targetIdentity.js"></script>
+  <script src="/default-client-settings.js"></script>
   <script src="client.js"></script>
   <script>
     (function () {

--- a/serverCore.js
+++ b/serverCore.js
@@ -31,6 +31,11 @@ const {
   shouldCloseBridgeSessionAfterEventStreamClose,
 } = require("./bridgeSessionLiveness");
 const { syncRuntimeExecutable } = require("./runtimeWorker");
+const {
+  normalizeConfiguredDefaultClientSettings,
+  resolveDefaultClientSettings,
+  serializeDefaultClientSettingsScript,
+} = require("./defaultClientSettings");
 
 const SERVER_APP_VERSION = resolveServerAppVersion();
 const CLIENT_ICE_CONFIG = resolveClientIceConfig(process.env);
@@ -530,6 +535,14 @@ app.get("/", (req, res) => {
   } catch (err) {
     res.status(500).send("Failed to load index.html");
   }
+});
+
+app.get("/default-client-settings.js", (req, res) => {
+  const config = loadRuntimeConfig() || {};
+  res.setHeader("Cache-Control", "no-store");
+  res.type("application/javascript").send(
+    serializeDefaultClientSettingsScript(config.defaultClientSettings)
+  );
 });
 
 function findSocketIoClientPath() {
@@ -3651,6 +3664,15 @@ app.get("/admin/settings/guest-login", requireAdmin, (req, res) => {
   }
 });
 
+app.get("/admin/settings/default-client", requireAdmin, (req, res) => {
+  const config = loadRuntimeConfig() || {};
+  res.json({
+    settings: resolveDefaultClientSettings(config.defaultClientSettings),
+    configured: Object.prototype.hasOwnProperty.call(config, "defaultClientSettings"),
+    configPath: getConfigPath(),
+  });
+});
+
 app.put("/admin/settings/mdns", requireAdmin, (req, res) => {
   const nextHost = normalizeMdnsSetting(req.body?.mdnsHost);
   if (!nextHost) {
@@ -3796,6 +3818,25 @@ app.put("/admin/settings/guest-login", requireAdmin, (req, res) => {
   }
 });
 
+app.put("/admin/settings/default-client", requireAdmin, (req, res) => {
+  try {
+    const settings = normalizeConfiguredDefaultClientSettings(req.body, { strict: true });
+    const currentConfig = loadRuntimeConfig() || {};
+    const updatedConfig = {
+      ...currentConfig,
+      defaultClientSettings: settings,
+    };
+    const configPath = saveRuntimeConfig(updatedConfig);
+    return res.json({
+      settings: resolveDefaultClientSettings(settings),
+      configured: true,
+      configPath,
+    });
+  } catch (err) {
+    return res.status(400).json({ error: err.message || "Invalid default client settings" });
+  }
+});
+
 app.get("/admin/config/export", requireAdmin, (req, res) => {
   try {
     const bundle = {
@@ -3891,6 +3932,19 @@ app.post("/admin/config/import", requireAdmin, (req, res) => {
           enabled: bundle.serverConfig.guestLogin.enabled === true,
           profileUserId: Number.isFinite(importedGuestProfileId) ? importedGuestProfileId : null,
         };
+      }
+
+      if (Object.prototype.hasOwnProperty.call(bundle.serverConfig, "defaultClientSettings")) {
+        try {
+          nextConfig.defaultClientSettings = normalizeConfiguredDefaultClientSettings(
+            bundle.serverConfig.defaultClientSettings,
+            { strict: true }
+          );
+        } catch (error) {
+          return res.status(400).json({
+            error: `Config file contains invalid default client settings: ${error.message}`,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- add optional multi-target talk locking while preserving the existing single-lock behavior
- add configurable server-side defaults for client audio and interaction settings without overriding personal browser settings
- align client/admin switches and compact the Admin config layout

## Testing
- npm test (63/63 passing under Node 24.18.1)