### PR TITLE
Add admin stop transmission control

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -1221,6 +1221,24 @@ function formatStatusPacketLoss(networkStats) {
   return `${packetLossPercent.toFixed(packetLossPercent >= 10 ? 0 : 1)}%`;
 }
 
+function syncStopTransmissionButtons(users = latestAdminStatus?.users || []) {
+  const statusByUserId = new Map(
+    (Array.isArray(users) ? users : []).map((user) => [Number(user.id), user])
+  );
+
+  document.querySelectorAll('[data-stop-transmission-user-id]').forEach((button) => {
+    if (button.dataset.requestPending === 'true') return;
+    const user = statusByUserId.get(Number(button.dataset.stopTransmissionUserId));
+    const canStop = Boolean(user?.online && user?.talking);
+    button.disabled = !canStop;
+    button.title = canStop
+      ? 'Immediately stop this user\'s active transmission'
+      : user?.online
+        ? 'User is not transmitting'
+        : 'User is offline';
+  });
+}
+
 function renderAdminStatus(payload = {}) {
   const canRestartServer = Boolean(adminState.isSuperAdmin && payload.restartSupported);
   containerRestartPanel?.classList.toggle('is-hidden', !canRestartServer);
@@ -1239,6 +1257,7 @@ function renderAdminStatus(payload = {}) {
   feeds.sort(sortByOnlineAndName);
   bridges.sort(sortByOnlineAndName);
   companions.sort(sortByOnlineAndName);
+  syncStopTransmissionButtons(users);
 
   setStatusText('status-summary-users', `${summary.usersOnline || 0} / ${summary.usersTotal || 0}`);
   setStatusText('status-summary-bridges', `${summary.bridgesOnline || 0} / ${summary.bridgesTotal || 0}`);
@@ -2340,6 +2359,9 @@ async function renderUserList(users, conferences, feeds, bridges = currentBridge
     const deleteAttrs = isGuestProfile
       ? 'disabled title="Guest profile cannot be deleted"'
       : isAdmin ? 'disabled title="Admin accounts cannot be deleted"' : '';
+    const stopTransmissionButton = !isSuperadmin && !isGuestProfile
+      ? `<button type="button" class="small warning" data-stop-transmission-user-id="${user.id}" onclick="stopUserTransmission(${user.id}, this)" disabled>Stop transmission</button>`
+      : '';
     const li = document.createElement('li');
     li.className = 'list-item entity-detail-item';
     li.dataset.entityId = String(user.id);
@@ -2423,6 +2445,7 @@ async function renderUserList(users, conferences, feeds, bridges = currentBridge
           <button type="button" class="small" onclick='copyUserLoginUrl(${user.id}, ${JSON.stringify(user.name)}, this)' ${loginLinkAttrs}>Copy Login URL</button>
           <button type="button" class="small warning" onclick='editUser(${user.id}, ${JSON.stringify(user.name)})'>Rename</button>
           <button type="button" class="small warning" onclick='resetPassword(${user.id}, ${JSON.stringify(user.name)})' ${passwordAttrs}>Reset Password</button>
+          ${stopTransmissionButton}
           ${adminToggle}
           <button type="button" class="small danger" onclick="deleteUser(${user.id})" ${deleteAttrs}>Delete</button>
         </div>
@@ -2462,6 +2485,7 @@ async function renderUserList(users, conferences, feeds, bridges = currentBridge
   }));
   initializeBridgeEndpointForms();
   await syncEntityMasterDetail('users', visibleUsers);
+  syncStopTransmissionButtons();
 }
 
 async function renderFeedList(feeds) {
@@ -3183,6 +3207,39 @@ window.editUser = async function (userId, currentName) {
   } catch (err) {
     showMessage('❌ Failed to update user', 'error', 'user');
     console.error(err);
+  }
+};
+
+window.stopUserTransmission = async function (userId, button) {
+  const userName = latestAdminStatus?.users?.find((user) => Number(user.id) === Number(userId))?.name || 'User';
+  if (button) {
+    button.dataset.requestPending = 'true';
+    button.disabled = true;
+  }
+
+  try {
+    const res = await authedFetch(`/admin/users/${userId}/stop-transmission`, { method: 'POST' });
+    const payload = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(payload.error || 'Failed to stop transmission');
+    }
+
+    const statusUser = latestAdminStatus?.users?.find((user) => Number(user.id) === Number(userId));
+    if (statusUser) statusUser.talking = false;
+
+    showMessage(
+      payload.stopped
+        ? `✅ Transmission stopped for ${userName}`
+        : `ℹ️ ${userName} was no longer transmitting`,
+      payload.stopped ? 'success' : 'warning',
+      'user'
+    );
+  } catch (err) {
+    console.error('Error stopping user transmission:', err);
+    showMessage(`❌ ${err.message}`, 'error', 'user');
+  } finally {
+    if (button) delete button.dataset.requestPending;
+    syncStopTransmissionButtons();
   }
 };
 

--- a/public/client.js
+++ b/public/client.js
@@ -991,6 +991,7 @@ let voiceTriggerRafId = null;
 let voiceTriggerActive = false;
 let voiceTriggerAboveSince = 0;
 let voiceTriggerBelowSince = 0;
+let voiceTriggerAdminInhibited = false;
 let settingsMonitorActive = false;
 let settingsMonitorPromise = null;
 let settingsMenuOpen = false;
@@ -7801,6 +7802,17 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
       const startThreshold = clampVoiceTriggerThresholdDb(voiceTriggerThresholdDb);
       const stopThreshold = Math.max(VOICE_TRIGGER_MIN_DB, startThreshold - VOICE_TRIGGER_HYSTERESIS_DB);
 
+      if (voiceTriggerAdminInhibited) {
+        voiceTriggerAboveSince = 0;
+        voiceTriggerBelowSince = 0;
+        if (!Number.isFinite(peakDb) || peakDb < stopThreshold) {
+          voiceTriggerAdminInhibited = false;
+        }
+        setVoiceTriggerState('armed');
+        voiceTriggerRafId = requestAnimationFrame(tick);
+        return;
+      }
+
       if (!voiceTriggerActive) {
         if (Number.isFinite(peakDb) && peakDb >= startThreshold) {
           if (!voiceTriggerAboveSince) {
@@ -7848,6 +7860,7 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
 
   function setVoiceTriggerEnabled(enabled, { persist = true } = {}) {
     voiceTriggerEnabled = !!enabled && isOperatorSession() && session.kind !== 'feed';
+    voiceTriggerAdminInhibited = false;
     if (voiceTriggerToggle) {
       voiceTriggerToggle.checked = voiceTriggerEnabled;
     }
@@ -11203,6 +11216,22 @@ function emitTargetAudioStateSnapshot(reason = 'target-audio-state') {
       }
     }
   }
+
+  socket.on('force-stop-transmission', () => {
+    clearSuspendedLockState();
+    if (voiceTriggerEnabled) {
+      voiceTriggerAdminInhibited = true;
+      voiceTriggerActive = false;
+      voiceTriggerAboveSince = 0;
+      voiceTriggerBelowSince = 0;
+      setVoiceTriggerState('armed');
+    }
+    handleStopTalking({
+      preventDefault() {},
+      currentTarget: null,
+      suppressLockRestore: true,
+    });
+  });
 
   // Safety stop so PTT can't get stuck on iOS/background transitions.
   function stopTalkingSafely({ respectLock = false, pointerId = null } = {}) {

--- a/serverCore.js
+++ b/serverCore.js
@@ -36,6 +36,7 @@ const {
   resolveDefaultClientSettings,
   serializeDefaultClientSettingsScript,
 } = require("./defaultClientSettings");
+const { stopPeerTransmission } = require("./transmissionControl");
 
 const SERVER_APP_VERSION = resolveServerAppVersion();
 const CLIENT_ICE_CONFIG = resolveClientIceConfig(process.env);
@@ -3420,6 +3421,81 @@ function buildAdminStatusSnapshot() {
 
 app.get("/admin/status", requireAdmin, (req, res) => {
   res.json(buildAdminStatusSnapshot());
+});
+
+async function forceStopUserTransmission(userId) {
+  const found = findUserPeerByUserId(userId);
+  if (!found?.peer) return null;
+
+  const { socketId, peer } = found;
+  const talkProducers = getPeerTalkProducers(peer, { includePaused: true });
+  const appleRecipientUserIds = [...new Set(talkProducers.flatMap((producer) => (
+    Array.isArray(producer?.__applePttRecipientUserIds) ? producer.__applePttRecipientUserIds : []
+  )))];
+  const result = await stopPeerTransmission(peer, talkProducers);
+
+  for (const producer of talkProducers) {
+    producer.__applePttRecipientUserIds = [];
+    if (String(producer?.appData?.type || "").trim().toLowerCase() === "talk") {
+      syncProducerRecipients({ producer, speakerSocketId: socketId });
+    }
+  }
+
+  try {
+    peer.socket?.emit("force-stop-transmission", {
+      reason: "admin-stop-transmission",
+      at: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.warn(`[ADMIN] Failed to notify user ${userId} about stopped transmission:`, error?.message || error);
+  }
+
+  syncPeerCompanionState(peer, { reason: "admin-stop-transmission" });
+  broadcastRuntimeUserStates("admin-stop-transmission");
+  void sendApplePttServiceUpdate({
+    recipientUserIds: appleRecipientUserIds,
+    reason: "admin-stop-transmission",
+  }).catch((error) => {
+    console.warn("[APPLE-PTT] Failed to send forced-stop update:", error?.message || error);
+  });
+
+  return result;
+}
+
+app.post("/admin/users/:id/stop-transmission", requireAdmin, async (req, res) => {
+  const userId = Number(req.params.id);
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return res.status(400).json({ error: "Invalid user id" });
+  }
+
+  const user = getUserById(userId);
+  if (!user || user.is_superadmin || user.is_guest_profile) {
+    return res.status(404).json({ error: "User not found" });
+  }
+
+  try {
+    const result = await forceStopUserTransmission(userId);
+    if (!result) {
+      return res.status(409).json({ error: "User is not online" });
+    }
+    if (result.errors.length > 0) {
+      console.error(`[ADMIN] Failed to stop all transmission producers for user ${userId}`, result.errors);
+      return res.status(500).json({ error: "Failed to stop all active transmission producers" });
+    }
+    console.log(
+      `[ADMIN] Stopped transmission for user ${userId} (${user.name}); `
+      + `paused=${result.pausedProducerCount}, closed=${result.closedProducerCount}`
+    );
+    return res.json({
+      ok: true,
+      stopped: result.hadActiveTransmission,
+      pausedProducerCount: result.pausedProducerCount,
+      closedProducerCount: result.closedProducerCount,
+    });
+  } catch (error) {
+    console.error(`[ADMIN] Failed to stop transmission for user ${userId}:`, error);
+    return res.status(500).json({ error: "Failed to stop transmission" });
+  }
 });
 
 app.post("/admin/restart", requireAdmin, requireSuperAdmin, (req, res) => {

--- a/transmissionControl.js
+++ b/transmissionControl.js
@@ -1,0 +1,50 @@
+function hasActiveTalkState(peer, producers = []) {
+  return Boolean(
+    peer?.pttTalking
+    || (Array.isArray(peer?.activeTalkTargets) && peer.activeTalkTargets.length > 0)
+    || producers.some((producer) => producer && !producer.closed && !producer.paused)
+  );
+}
+
+async function stopPeerTransmission(peer, producers = []) {
+  if (!peer || typeof peer !== "object") {
+    throw new TypeError("Peer is required");
+  }
+
+  const uniqueProducers = [...new Set(producers.filter(Boolean))];
+  const hadActiveTransmission = hasActiveTalkState(peer, uniqueProducers);
+  peer.activeTalkTargets = [];
+  peer.pttTalking = false;
+  peer.pttStartedAt = 0;
+
+  let pausedProducerCount = 0;
+  let closedProducerCount = 0;
+  const errors = [];
+
+  for (const producer of uniqueProducers) {
+    if (producer.closed || producer.paused) continue;
+    try {
+      await producer.pause();
+      pausedProducerCount += 1;
+    } catch (pauseError) {
+      try {
+        producer.close();
+        closedProducerCount += 1;
+      } catch (closeError) {
+        errors.push(closeError || pauseError);
+      }
+    }
+  }
+
+  return {
+    hadActiveTransmission,
+    pausedProducerCount,
+    closedProducerCount,
+    errors,
+  };
+}
+
+module.exports = {
+  hasActiveTalkState,
+  stopPeerTransmission,
+};

--- a/transmissionControl.test.js
+++ b/transmissionControl.test.js
@@ -1,0 +1,50 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { stopPeerTransmission } = require("./transmissionControl");
+
+test("clears the peer talk state and pauses active producers", async () => {
+  const peer = {
+    pttTalking: true,
+    pttStartedAt: 123,
+    activeTalkTargets: [{ type: "conference", id: 7 }],
+  };
+  const producer = {
+    paused: false,
+    closed: false,
+    async pause() { this.paused = true; },
+  };
+
+  const result = await stopPeerTransmission(peer, [producer]);
+
+  assert.equal(result.hadActiveTransmission, true);
+  assert.equal(result.pausedProducerCount, 1);
+  assert.deepEqual(peer.activeTalkTargets, []);
+  assert.equal(peer.pttTalking, false);
+  assert.equal(peer.pttStartedAt, 0);
+});
+
+test("falls back to closing a producer when pausing fails", async () => {
+  const peer = { pttTalking: false, activeTalkTargets: [] };
+  const producer = {
+    paused: false,
+    closed: false,
+    async pause() { throw new Error("pause failed"); },
+    close() { this.closed = true; },
+  };
+
+  const result = await stopPeerTransmission(peer, [producer]);
+
+  assert.equal(result.closedProducerCount, 1);
+  assert.equal(result.errors.length, 0);
+});
+
+test("is idempotent when the user is no longer transmitting", async () => {
+  const peer = { pttTalking: false, pttStartedAt: 0, activeTalkTargets: [] };
+  const producer = { paused: true, closed: false, async pause() {} };
+
+  const result = await stopPeerTransmission(peer, [producer]);
+
+  assert.equal(result.hadActiveTransmission, false);
+  assert.equal(result.pausedProducerCount, 0);
+});


### PR DESCRIPTION
Adds an admin action to immediately stop an active user transmission.

- pauses all active talk producers and clears server-side targets
- resets client talk locks and UI state
- prevents level trigger from immediately restarting until the signal drops
- enables the admin button only while the user is transmitting
- adds focused transmission control tests

Tested with Node 24.18.1: `npm test` (66 passing).