### PR TITLE
Fix Edge audio prewarm and Node 24 SQLite cleanup

### DIFF
--- a/betterSqliteBinding.js
+++ b/betterSqliteBinding.js
@@ -1,0 +1,62 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function isLinuxMusl(report = process.report) {
+  if (process.platform !== "linux") return false;
+  try {
+    return !report?.getReport?.()?.header?.glibcVersionRuntime;
+  } catch {
+    return false;
+  }
+}
+
+function getBetterSqliteTarget({
+  platform = process.platform,
+  arch = process.arch,
+  linuxMusl = platform === "linux" && isLinuxMusl(),
+} = {}) {
+  const supportedPlatforms = new Set(["darwin", "linux", "win32"]);
+  const supportedArchitectures = new Set(["arm64", "x64"]);
+  if (!supportedPlatforms.has(platform) || !supportedArchitectures.has(arch)) {
+    return null;
+  }
+  const platformName = platform === "linux" && linuxMusl ? "linuxmusl" : platform;
+  return `${platformName}-${arch}`;
+}
+
+function getBetterSqlitePackageRoot() {
+  return path.dirname(require.resolve("better-sqlite3/package.json"));
+}
+
+function getBetterSqliteBindingCandidates({
+  packageRoot = getBetterSqlitePackageRoot(),
+  platform = process.platform,
+  arch = process.arch,
+  linuxMusl = platform === "linux" && isLinuxMusl(),
+} = {}) {
+  const target = getBetterSqliteTarget({ platform, arch, linuxMusl });
+  const candidates = [];
+  if (target) {
+    candidates.push(path.join(packageRoot, "prebuilds", `${target}.node`));
+  }
+  // Kept as a fallback and as the canonical location staged for pkg builds.
+  candidates.push(path.join(packageRoot, "build", "Release", "better_sqlite3.node"));
+  return candidates;
+}
+
+function resolveBetterSqliteBinding(options = {}) {
+  const candidates = getBetterSqliteBindingCandidates(options);
+  const sourcePath = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!sourcePath) {
+    throw new Error(`better_sqlite3.node is missing. Checked: ${candidates.join(", ")}`);
+  }
+  return sourcePath;
+}
+
+module.exports = {
+  getBetterSqliteBindingCandidates,
+  getBetterSqlitePackageRoot,
+  getBetterSqliteTarget,
+  isLinuxMusl,
+  resolveBetterSqliteBinding,
+};

--- a/betterSqliteBinding.test.js
+++ b/betterSqliteBinding.test.js
@@ -1,0 +1,44 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  getBetterSqliteBindingCandidates,
+  getBetterSqliteTarget,
+  resolveBetterSqliteBinding,
+} = require("./betterSqliteBinding");
+
+test("uses the N-API better-sqlite3 generation that replaces the Node 24 ObjectWrap path", () => {
+  const { version } = require("better-sqlite3/package.json");
+  assert.equal(version, "13.0.3");
+});
+
+test("selects the platform-specific N-API prebuild", () => {
+  assert.equal(getBetterSqliteTarget({ platform: "darwin", arch: "arm64" }), "darwin-arm64");
+  assert.equal(
+    getBetterSqliteTarget({ platform: "linux", arch: "x64", linuxMusl: true }),
+    "linuxmusl-x64"
+  );
+  assert.equal(getBetterSqliteTarget({ platform: "freebsd", arch: "x64" }), null);
+});
+
+test("prefers a shipped prebuild and falls back to the staged pkg binding", (t) => {
+  const packageRoot = fs.mkdtempSync(path.join(os.tmpdir(), "talktome-sqlite-binding-"));
+  t.after(() => fs.rmSync(packageRoot, { recursive: true, force: true }));
+
+  const candidates = getBetterSqliteBindingCandidates({
+    packageRoot,
+    platform: "win32",
+    arch: "x64",
+  });
+  const [prebuildPath, stagedPath] = candidates;
+  fs.mkdirSync(path.dirname(stagedPath), { recursive: true });
+  fs.writeFileSync(stagedPath, "staged");
+  assert.equal(resolveBetterSqliteBinding({ packageRoot, platform: "win32", arch: "x64" }), stagedPath);
+
+  fs.mkdirSync(path.dirname(prebuildPath), { recursive: true });
+  fs.writeFileSync(prebuildPath, "prebuild");
+  assert.equal(resolveBetterSqliteBinding({ packageRoot, platform: "win32", arch: "x64" }), prebuildPath);
+});

--- a/db.js
+++ b/db.js
@@ -4,19 +4,12 @@ const path = require("path");
 const Database = require("better-sqlite3");
 const { getDataDir, getDataFile } = require("./dataPaths");
 const { syncRuntimeFile } = require("./runtimeWorker");
+const { getBetterSqliteBindingCandidates } = require("./betterSqliteBinding");
 
 function resolveNativeBinding() {
   const execDir = path.dirname(process.execPath);
-  const bundledPath = path.join(
-    __dirname,
-    "node_modules",
-    "better-sqlite3",
-    "build",
-    "Release",
-    "better_sqlite3.node"
-  );
   const candidates = [
-    bundledPath,
+    ...getBetterSqliteBindingCandidates(),
     path.join(execDir, "binaries", "better_sqlite3.node"),
     path.join(execDir, "better_sqlite3.node"),
   ];

--- a/nativeBindingRuntime.test.js
+++ b/nativeBindingRuntime.test.js
@@ -6,6 +6,7 @@ const { spawnSync } = require("node:child_process");
 const test = require("node:test");
 
 const { fileSha256 } = require("./runtimeWorker");
+const { resolveBetterSqliteBinding } = require("./betterSqliteBinding");
 
 test("unpackaged and Docker server replace a stale persisted SQLite binding", (t) => {
   const dataDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "talktome-native-binding-"));
@@ -26,13 +27,6 @@ test("unpackaged and Docker server replace a stale persisted SQLite binding", (t
   });
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  const installedBinding = path.join(
-    __dirname,
-    "node_modules",
-    "better-sqlite3",
-    "build",
-    "Release",
-    "better_sqlite3.node"
-  );
+  const installedBinding = resolveBetterSqliteBinding();
   assert.equal(fileSha256(runtimeBinding), fileSha256(installedBinding));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bcryptjs": "^3.0.2",
-        "better-sqlite3": "^11.10.0",
+        "better-sqlite3": "13.0.3",
         "express": "^4.18.2",
         "mediasoup": "^3.26.0",
         "mediasoup-client": "^3.22.0",
@@ -1294,6 +1294,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1342,29 +1343,22 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
-      "hasInstallScript": true,
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -1441,6 +1435,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1723,6 +1718,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -1738,6 +1734,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -1766,6 +1763,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1866,6 +1864,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -2172,6 +2171,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
@@ -2317,12 +2317,6 @@
         "node": "^12.20 || >= 14.13"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -2404,6 +2398,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -2480,6 +2475,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/gopd": {
@@ -2610,6 +2606,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2656,6 +2653,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/interpret": {
@@ -3017,6 +3015,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3029,6 +3028,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3120,6 +3120,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -3157,6 +3158,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -3179,12 +3181,22 @@
       "version": "3.94.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
       "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-domexception": {
@@ -3288,6 +3300,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3468,6 +3481,7 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -3494,12 +3508,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/prebuild-install/node_modules/tar-fs": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
       "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -3512,6 +3528,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
@@ -3558,6 +3575,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -3691,6 +3709,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -3706,6 +3725,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -3881,6 +3901,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4058,6 +4079,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4078,6 +4100,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4336,6 +4359,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -4371,6 +4395,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4535,6 +4560,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -4640,6 +4666,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -4865,6 +4892,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "radio:stream": "node gateway/radioGateway.js stream",
     "radio:stream-rx": "node gateway/radioGateway.js stream-rx",
     "gateway:sync": "scripts/sync-gateway-to-pi.sh",
-    "prebuild:pkg": "node scripts/verify-build-node.js && node scripts/resolve-build-version.js --version-json build-version.json && npm rebuild better-sqlite3",
+    "prebuild:pkg": "node scripts/verify-build-node.js && node scripts/resolve-build-version.js --version-json build-version.json && node scripts/stage-better-sqlite3-binding.js",
     "build:win64": "npm run prebuild:pkg && npx --no-install pkg package.json --targets node24-win-x64 --output talktome_win64 && node scripts/copy-runtime-deps.js win64",
     "build:mac_arm64": "npm run prebuild:pkg && npx --no-install pkg package.json --targets node24-macos-arm64 --output talktome_arm64 && node scripts/copy-runtime-deps.js mac_arm64"
   },
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",
-    "better-sqlite3": "^11.10.0",
+    "better-sqlite3": "13.0.3",
     "express": "^4.18.2",
     "mediasoup": "^3.26.0",
     "mediasoup-client": "^3.22.0",
@@ -54,7 +54,7 @@
     ]
   },
   "allowScripts": {
-    "better-sqlite3@11.10.0": true,
+    "better-sqlite3@13.0.3": true,
     "esbuild@0.28.2": true,
     "mediasoup@3.26.0": true
   }

--- a/public/client.js
+++ b/public/client.js
@@ -259,6 +259,7 @@ let feedDimIncoming = hasServerDefaultClientSetting('dimWhenAddressed')
 let audioProcessingEnabled = false;
 let audioProcessingReinitializePending = false;
 let refreshTalkProducerForAudioProcessingChange = null;
+let ensureWarmTalkProducerAfterMicAccess = () => Promise.resolve(null);
 let leftHandModeEnabled = hasServerDefaultClientSetting('leftHandMode')
   ? serverDefaultClientSettings.leftHandMode === true
   : false;
@@ -2019,7 +2020,7 @@ async function requestInitialMicrophoneAccess({ reason = 'startup' } = {}) {
     }
 
     if (mediaInitialized && isOperatorSession() && session.kind === 'user') {
-      ensureWarmTalkProducer(`initial-mic-access:${reason}`).catch((error) => {
+      ensureWarmTalkProducerAfterMicAccess(`initial-mic-access:${reason}`).catch((error) => {
         console.warn('Failed to pre-warm talk producer after microphone access:', error);
       });
     }
@@ -4626,6 +4627,8 @@ let cachedOperatorTargets = null;
       warmTalkProducerPromise = null;
     }
   }
+
+  ensureWarmTalkProducerAfterMicAccess = ensureWarmTalkProducer;
 
   refreshTalkProducerForAudioProcessingChange = async function () {
     if (session.kind !== 'user') {

--- a/scripts/copy-runtime-deps.js
+++ b/scripts/copy-runtime-deps.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const { resolveBetterSqliteBinding } = require("../betterSqliteBinding");
 
 const target = String(process.argv[2] || "").trim().toLowerCase();
 
@@ -9,14 +10,7 @@ if (!target) {
 }
 
 const rootDir = path.resolve(__dirname, "..");
-const sqliteSource = path.join(
-  rootDir,
-  "node_modules",
-  "better-sqlite3",
-  "build",
-  "Release",
-  "better_sqlite3.node"
-);
+const sqliteSource = resolveBetterSqliteBinding();
 
 const workerName = target === "win64" ? "mediasoup-worker.exe" : "mediasoup-worker";
 const workerSource = path.join(

--- a/scripts/stage-better-sqlite3-binding.js
+++ b/scripts/stage-better-sqlite3-binding.js
@@ -1,0 +1,17 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  getBetterSqlitePackageRoot,
+  resolveBetterSqliteBinding,
+} = require("../betterSqliteBinding");
+
+const packageRoot = getBetterSqlitePackageRoot();
+const sourcePath = resolveBetterSqliteBinding({ packageRoot });
+const stagedPath = path.join(packageRoot, "build", "Release", "better_sqlite3.node");
+
+fs.mkdirSync(path.dirname(stagedPath), { recursive: true });
+if (path.resolve(sourcePath) !== path.resolve(stagedPath)) {
+  fs.copyFileSync(sourcePath, stagedPath);
+}
+console.log(`[build] staged better-sqlite3 binding from ${path.basename(sourcePath)}`);


### PR DESCRIPTION
## Summary
- fix the Edge microphone prewarm scope race that prevented short first PTT transmissions
- upgrade to the N-API better-sqlite3 runtime to avoid Node 24 cleanup crashes
- stage the correct native SQLite binding for packaged builds

## Verification
- Edge user-to-user audio tested successfully
- 69/69 Node 24 tests pass
- npm production audit reports 0 vulnerabilities
- prior Windows/macOS/Docker build for the SQLite commit passed