### PR TITLE
Fix settings monitor and add routing diagnostics

### DIFF
--- a/clientSettingsScope.test.js
+++ b/clientSettingsScope.test.js
@@ -1,0 +1,33 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const clientSource = fs.readFileSync(
+  path.join(__dirname, "public", "client.js"),
+  "utf8",
+);
+
+function sourceBetween(startMarker, endMarker) {
+  const start = clientSource.indexOf(startMarker);
+  const end = clientSource.indexOf(endMarker, start + startMarker.length);
+  assert.notEqual(start, -1, `Missing source marker: ${startMarker}`);
+  assert.notEqual(end, -1, `Missing source marker: ${endMarker}`);
+  return clientSource.slice(start, end);
+}
+
+test("settings handlers do not reference the closure-scoped cached user list", () => {
+  const openHandler = sourceBetween(
+    "function handleSettingsMenuOpened()",
+    "function handleSettingsMenuClosed()",
+  );
+  const viewHandler = sourceBetween(
+    "function setActiveSettingsView(",
+    "function bindSettingsViewButton(",
+  );
+
+  assert.match(openHandler, /refreshTargetHotkeyUiHandler\(\);/);
+  assert.doesNotMatch(openHandler, /cachedUsers/);
+  assert.match(viewHandler, /renderTargetHotkeySettingsHandler\(\);/);
+  assert.doesNotMatch(viewHandler, /cachedUsers/);
+});

--- a/public/client.js
+++ b/public/client.js
@@ -2125,7 +2125,10 @@ function handleSettingsMenuOpened() {
   if (settingsMenuOpen) return;
   settingsMenuOpen = true;
   setActiveSettingsView('main');
-  refreshTargetHotkeyUiHandler(cachedUsers);
+  // The assigned handler owns the current user list inside the
+  // DOMContentLoaded scope. Passing that closure-scoped variable here used
+  // to throw because this function lives outside that scope.
+  refreshTargetHotkeyUiHandler();
   startInputMonitor();
 }
 
@@ -2157,7 +2160,7 @@ function setActiveSettingsView(nextView = 'main') {
   }
 
   if (resolvedView === 'shortcuts') {
-    renderTargetHotkeySettingsHandler(cachedUsers);
+    renderTargetHotkeySettingsHandler();
   }
 }
 

--- a/serverCore.js
+++ b/serverCore.js
@@ -6754,6 +6754,53 @@ function closeProducerConsumersForRecipient({ producerId, recipientSocketId }) {
   }
 }
 
+function getProducerRoutingTargets(producer, speakerPeer) {
+  const type = String(producer?.appData?.type || "").trim().toLowerCase();
+  if (type === "talk") {
+    return normalizeRuntimeTalkTargets(speakerPeer?.activeTalkTargets || []);
+  }
+  if (["user", "conference", "guest"].includes(type)) {
+    return normalizeRuntimeTalkTargets([{ type, id: producer?.appData?.id }]);
+  }
+  return [];
+}
+
+function buildConferenceRoutingDiagnostics(targets, speakerSocketId) {
+  return targets
+    .filter((target) => target?.type === "conference")
+    .map((target) => ({
+      conferenceId: Number(target.id),
+      activePeers: Array.from(peers.entries())
+        .filter(([socketId, peer]) => socketId !== speakerSocketId && isOperatorPeer(peer))
+        .map(([socketId, peer]) => ({
+          socketId,
+          kind: peer.kind || null,
+          userId: peer.userId ?? null,
+          guestProfileUserId: peer.guestProfileUserId ?? null,
+          productionId: peer.productionId ?? null,
+          recognizedMember: isPeerMemberOfConference(peer, target.id),
+        })),
+    }));
+}
+
+function warnIfActiveProducerHasNoRecipients({ producer, speakerSocketId, speakerPeer, deliveries }) {
+  if (!producer || producer.paused || deliveries.length > 0) return;
+  const targets = getProducerRoutingTargets(producer, speakerPeer);
+  if (targets.length === 0) return;
+
+  console.warn(`[ROUTE][WARN] Active producer ${producer.id} has no recipients ${JSON.stringify({
+    speaker: {
+      socketId: speakerSocketId,
+      kind: speakerPeer?.kind || null,
+      userId: speakerPeer?.userId ?? null,
+      guestProfileUserId: speakerPeer?.guestProfileUserId ?? null,
+      productionId: speakerPeer?.productionId ?? null,
+    },
+    targets,
+    conferences: buildConferenceRoutingDiagnostics(targets, speakerSocketId),
+  })}`);
+}
+
 function syncProducerRecipients({ producer, speakerSocketId, forceAnnounce = false }) {
   if (!producer) return [];
 
@@ -6762,6 +6809,12 @@ function syncProducerRecipients({ producer, speakerSocketId, forceAnnounce = fal
   const deliveries = resolveProducerRecipientDeliveries({
     appData: producer.appData,
     speakerSocketId,
+  });
+  warnIfActiveProducerHasNoRecipients({
+    producer,
+    speakerSocketId,
+    speakerPeer,
+    deliveries,
   });
   const previousDeliveries = producer.__recipientDeliveries instanceof Map
     ? producer.__recipientDeliveries
@@ -7460,6 +7513,10 @@ io.on("connection", (socket) => {
 
     try {
       await producer.pause();
+      console.log(
+        `[SIGNAL] pause-producer ok socket=${socket.id} user=${peer.userId ?? peer.guestProfileUserId ?? "unknown"} `
+        + `producer=${producer.id} type=${producer.appData?.type || "unknown"}`
+      );
       callback({ ok: true });
     } catch (error) {
       console.error("[SIGNAL] pause-producer failed:", error);
@@ -7477,6 +7534,10 @@ io.on("connection", (socket) => {
 
     try {
       await producer.resume();
+      console.log(
+        `[SIGNAL] resume-producer ok socket=${socket.id} user=${peer.userId ?? peer.guestProfileUserId ?? "unknown"} `
+        + `producer=${producer.id} type=${producer.appData?.type || "unknown"}`
+      );
       callback({ ok: true });
     } catch (error) {
       console.error("[SIGNAL] resume-producer failed:", error);
@@ -7969,12 +8030,15 @@ io.on("connection", (socket) => {
           //----------------------------------------------------------------
           // 3️⃣  Routing
           //----------------------------------------------------------------
-          announceProducerToRecipients({
+          const initialRecipientSocketIds = announceProducerToRecipients({
             producerId: producer.id,
             appData,
             speakerSocketId: socket.id,
           });
-          console.log(`[ROUTE] Announced producer ${producer.id} for ${type} ${targetId ?? ""}`.trim());
+          console.log(
+            `[ROUTE] Announced producer ${producer.id} for ${type} ${targetId ?? ""} `
+            + `recipients=${initialRecipientSocketIds.length}`
+          );
 
           const applePttRecipientUserIds = await sendApplePttSpeakerStarted({
             type,
@@ -7996,12 +8060,16 @@ io.on("connection", (socket) => {
             producer.__startedAt = Date.now();
             syncPeerCompanionState(peer, { reason: "produce-resumed" });
             broadcastRuntimeUserStates("produce-resumed");
-            announceProducerToRecipients({
+            const resumedRecipientSocketIds = announceProducerToRecipients({
               producerId: producer.id,
               appData,
               speakerSocketId: socket.id,
               forceAnnounce: true,
             });
+            console.log(
+              `[ROUTE] Re-announced resumed producer ${producer.id} for ${type} ${targetId ?? ""} `
+              + `recipients=${resumedRecipientSocketIds.length}`
+            );
             void sendApplePttSpeakerStarted({
               type,
               targetId,


### PR DESCRIPTION
## Summary
- fix the out-of-scope `cachedUsers` reference in settings UI handlers
- log actual recipient counts when producers are announced
- warn with conference, sender, active peer, membership and production details when an active producer has no recipients
- log successful producer pause and resume operations
- add a regression test for the settings scope issue

## Scope
This intentionally does not change conference routing behavior, so it remains compatible with the upcoming unified production matrix work.

## Tests
- Node.js 24 syntax checks
- 71/71 tests passing on main
- 69/69 tests passing after cherry-picking onto `feature/unified-production-matrix`