### PR TITLE
Keep Reply on the left in landscape left-hand mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1991,6 +1991,14 @@
           min-height: 0;
         }
 
+        body.left-hand-mode #intercom-app[style*="flex"] {
+          grid-template-columns: var(--phone-landscape-reply-width) minmax(0, 1fr);
+          grid-template-areas:
+            "session session"
+            "feed feed"
+            "reply targets";
+        }
+
         body.feed-mode #intercom-app {
           display: flex !important;
         }


### PR DESCRIPTION
## Summary
- place the large Reply control on the left in smartphone landscape mode when Left-hand mode is enabled
- keep the existing right-hand landscape layout unchanged

The same isolated commit is already present on `feature/unified-production-matrix`.